### PR TITLE
Update Makefile to properly exit when build fails!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ hw-opt:
 	$(QUESTA) vopt +acc=npr -o vopt_tb redmule_tb -floatparameters+redmule_tb -work $(BUILD_DIR)
 
 hw-compile:
-	$(QUESTA) vsim -c +incdir+$(UVM_HOME) -do 'source $(compile_script); quit'
+	$(QUESTA) vsim -c +incdir+$(UVM_HOME) -do 'quit - code [source $(compile_script)]'
 
 hw-lib:
 	@touch modelsim.ini


### PR DESCRIPTION
The `hw-compile` rule was wrong: it exits without error code even when the compilation fails. With this one-line change, the exit code of QuestaSim should correspond to the error code of the internal `vlog` command, crashing the simulation (as appropriate) instead of triggering silent errors.