### PR TITLE
Align `REGFILE_SCM` name in `hwpe_ctrl_slave` and remove randome trailing spaces.

### DIFF
--- a/rtl/redmule_ctrl.sv
+++ b/rtl/redmule_ctrl.sv
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 2022-2023 ETH Zurich and University of Bologna
  *
- * Licensed under the Solderpad Hardware License, Version 0.51 
- * (the "License"); you may not use this file except in compliance 
+ * Licensed under the Solderpad Hardware License, Version 0.51
+ * (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: SHL-0.51
  *
  * Authors: Yvan Tortorella <yvan.tortorella@unibo.it>
- * 
+ *
  * RedMulE Control Unit
  */
 
@@ -33,7 +33,7 @@ parameter  int unsigned Width         = 8                      ,
 parameter  int unsigned NumPipeRegs   = 3                      ,
 localparam int unsigned TILE          = (NumPipeRegs +1)*Height,
 localparam int unsigned W_ITERS       = W_ITERS                ,
-localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS            
+localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
 )(
   input  logic                    clk_i             ,
   input  logic                    rst_ni            ,
@@ -81,7 +81,7 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
 
   // Control slave interface
   hwpe_ctrl_slave  #(
-    .RegfileScm     ( RegfileScm   ),
+    .REGFILE_SCM    ( RegfileScm   ),
     .N_CORES        ( N_CORES      ),
     .N_CONTEXT      ( N_CONTEXT    ),
     .N_IO_REGS      ( REDMULE_REGS ),
@@ -105,7 +105,7 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
     if(~rst_ni) begin
        current <= REDMULE_IDLE;
     end else begin
-      if (clear) 
+      if (clear)
         current <= REDMULE_IDLE;
       else
         current <= next;
@@ -117,14 +117,14 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
     if(~rst_ni) begin
       w_row_count_q <= '0;
     end else begin
-      if (clear) 
+      if (clear)
         w_row_count_q <= '0;
       else
         w_row_count_q <= w_row_count_d;
     end
   end
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin 
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if(~rst_ni) begin
       count_w_q <= 1'b0;
     end else begin
@@ -179,7 +179,7 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
     end else begin
       if (last_w_row_rst || clear)
         last_w_row <= 1'b0;
-      else if (last_w_row_en) 
+      else if (last_w_row_en)
         last_w_row <= 1'b1;
     end
   end
@@ -192,7 +192,7 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
     if(~rst_ni) begin
       z_storings_q <= '0;
     end else begin
-      if (clear || storing_rst) 
+      if (clear || storing_rst)
         z_storings_q <= '0;
       else
         z_storings_q <= z_storings_d;
@@ -210,7 +210,7 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
   /*---------------------------------------------------------------------------------------------*/
   /*                                        Controller FSM                                       */
   /*---------------------------------------------------------------------------------------------*/
-  // This is a local FSM who's only work is to make the first 
+  // This is a local FSM who's only work is to make the first
   // input load operation and to start the redmule_scheduler
   always_comb begin : controller_fsm
     cntrl_scheduler_o  = '0;
@@ -245,10 +245,10 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
           z_buffer_clk_en = 1'b1;
         if (flgs_slave.start || test_mode_i)
           next = REDMULE_STARTING;
-        else 
+        else
           next = REDMULE_IDLE;
       end
-  
+
       REDMULE_STARTING: begin
         w_shift_o              = 1'b0;
         cntrl_scheduler_o.first_load = 1'b1;
@@ -262,7 +262,7 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
       REDMULE_COMPUTING: begin
         if (w_loaded_i)
           w_row_count_d = w_row_count_q + 1;
-        
+
         if (w_row_count_d == Height && !count_w_q)
           w_computed_en = 1'b1;
         else if (w_row_count_q == w_rows_iter) begin
@@ -271,7 +271,7 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
           if (!last_w_row)
             last_w_row_en = 1'b1;
         end
-        
+
         case (last_w_row)
           1'b0: begin
             if (w_computed == Height - 1) begin
@@ -295,7 +295,7 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
           end
         endcase
       end
-  
+
       REDMULE_BUFFERING: begin
         z_buffer_clk_en = 1'b1;
         if (last_w_row)
@@ -310,10 +310,10 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
         else
           next = REDMULE_BUFFERING;
       end
-  
+
       REDMULE_STORING: begin
         cntrl_scheduler_o.storing = 1'b1;
-      
+
         if (w_loaded_i)
           w_row_count_d = w_row_count_q + 1;
 
@@ -329,7 +329,7 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
           end
         end
       end
-  
+
       REDMULE_FINISHED: begin
         cntrl_slave.done = 1'b1;
         busy_o           = 1'b0;
@@ -351,6 +351,6 @@ localparam int unsigned LEFT_PARAMS   = LEFT_PARAMS
   /*                            Other combinational assigmnets                                   */
   /*---------------------------------------------------------------------------------------------*/
   assign evt_o   = flgs_slave.evt[7:0];
-  assign clear_o = clear; 
+  assign clear_o = clear;
 
 endmodule : redmule_ctrl


### PR DESCRIPTION
Align the parameter name to the one used in https://github.com/pulp-platform/hwpe-ctrl/commit/a5966201aeeb988d607accdc55da933a53c6a56e. Should we modify also the internal parameter name?