### PR TITLE
Update ECC-extended HCI integration.

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -1,4 +1,20 @@
 packages:
+  apb:
+    revision: 77ddf073f194d44b9119949d2421be59789e69ae
+    version: 0.2.4
+    source:
+      Git: https://github.com/pulp-platform/apb.git
+    dependencies:
+    - common_cells
+  axi:
+    revision: 2f395b176bee1c769c80f060a4345fda965bb04b
+    version: 0.38.0
+    source:
+      Git: https://github.com/pulp-platform/axi.git
+    dependencies:
+    - common_cells
+    - common_verification
+    - tech_cells_generic
   cluster_interconnect:
     revision: 7d0a4f8acae71a583a6713cab5554e60b9bb8d27
     version: 1.2.1
@@ -7,8 +23,8 @@ packages:
     dependencies:
     - common_cells
   common_cells:
-    revision: 2bd027cb87eaa9bf7d17196ec5f69864b35b630f
-    version: 1.32.0
+    revision: 0d67563b6b592549542544f1abc0f43e5d4ee8b4
+    version: 1.35.0
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:
@@ -45,14 +61,17 @@ packages:
     dependencies:
     - common_cells
   hci:
-    revision: 4823e503851eb7e8cc765a58621d767a01d6a77b
+    revision: 79aae747ec9562e94dd2e34bb937583696c02282
     version: null
     source:
       Git: https://github.com/pulp-platform/hci.git
     dependencies:
     - cluster_interconnect
+    - common_cells
     - hwpe-stream
     - l2_tcdm_hybrid_interco
+    - redundancy_cells
+    - register_interface
   hwpe-ctrl:
     revision: a5966201aeeb988d607accdc55da933a53c6a56e
     version: null
@@ -61,8 +80,8 @@ packages:
     dependencies:
     - tech_cells_generic
   hwpe-stream:
-    revision: 389bd7fb1975d2df1546910c5f220c668122e646
-    version: 1.6.5
+    revision: 65c99a4a2f37a79acee800ab0151f67dfb1edef1
+    version: 1.8.0
     source:
       Git: https://github.com/pulp-platform/hwpe-stream.git
     dependencies:
@@ -73,6 +92,25 @@ packages:
     source:
       Git: https://github.com/pulp-platform/L2_tcdm_hybrid_interco.git
     dependencies: []
+  redundancy_cells:
+    revision: c37bdb47339bf70e8323de8df14ea8bbeafb6583
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/redundancy_cells.git
+    dependencies:
+    - common_cells
+    - common_verification
+    - register_interface
+    - tech_cells_generic
+  register_interface:
+    revision: 146501d80052b61475cdc333d3aab4cd769fd5dc
+    version: 0.3.9
+    source:
+      Git: https://github.com/pulp-platform/register_interface.git
+    dependencies:
+    - apb
+    - axi
+    - common_cells
   tech_cells_generic:
     revision: 7968dd6e6180df2c644636bc6d2908a49f2190cf
     version: 0.2.13

--- a/Bender.yml
+++ b/Bender.yml
@@ -24,7 +24,7 @@ package:
 dependencies:
   cv32e40p          : { git: "https://github.com/pulp-platform/cv32e40p.git"          , rev: "pulpissimo-v4.1.0"                      }
   hwpe-stream       : { git: "https://github.com/pulp-platform/hwpe-stream.git"       , version: 1.6                                  }
-  hci               : { git: "https://github.com/pulp-platform/hci.git"               , rev: "e670b1c"                                } # branch: lg/ecc
+  hci               : { git: "https://github.com/pulp-platform/hci.git"               , rev: "79aae74"                                } # branch: lg/ecc
   hwpe-ctrl         : { git: "https://github.com/pulp-platform/hwpe-ctrl.git"         , rev: a5966201aeeb988d607accdc55da933a53c6a56e } # branch: master
   fpnew             : { git: "https://github.com/pulp-platform/cvfpu.git"             , rev: "pulp-v0.1.3"                            }
   common_cells      : { git: "https://github.com/pulp-platform/common_cells.git"      , version: 1.21.0                               }

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ XLEN           ?= 32
 XTEN           ?= imc
 
 compile_script ?= scripts/compile.tcl
-compile_flag   ?= -suppress 2583 -suppress 13314
+compile_flag   ?= -suppress 2583 -suppress 13314 -suppress 13169
 
 INI_PATH  = $(mkfile_path)/modelsim.ini
 WORK_PATH = $(BUILD_DIR)
@@ -41,6 +41,7 @@ WORK_PATH = $(BUILD_DIR)
 gui      ?= 0
 ipstools ?= 0
 P_STALL  ?= 0.0
+USE_ECC  ?= 0
 
 ifeq ($(verbose),1)
 FLAGS += -DVERBOSE
@@ -98,7 +99,9 @@ ifeq ($(gui), 0)
 	$(QUESTA) vsim -c vopt_tb -do "run -a" \
 	-gSTIM_INSTR=stim_instr.txt            \
 	-gSTIM_DATA=stim_data.txt              \
-	-gPROB_STALL=$(P_STALL)
+	-gPROB_STALL=$(P_STALL)                \
+	-gUSE_ECC=$(USE_ECC)                   \
+		-suppress vsim-3009
 else
 	cd $(BUILD_DIR)/$(TEST_SRCS);      \
 	$(QUESTA) vsim vopt_tb             \
@@ -106,7 +109,9 @@ else
 	-do "source $(WAVES)"              \
 	-gSTIM_INSTR=stim_instr.txt        \
 	-gSTIM_DATA=stim_data.txt          \
-	-gPROB_STALL=$(P_STALL)
+	-gPROB_STALL=$(P_STALL)            \
+	-gUSE_ECC=$(USE_ECC)               \
+		-suppress vsim-3009
 endif
 
 # Download bender
@@ -161,7 +166,7 @@ hw-clean-all:
 	rm -rf .cached_ipdb.json
 
 hw-opt:
-	$(QUESTA) vopt +acc=npr -o vopt_tb redmule_tb -floatparameters+redmule_tb -work $(BUILD_DIR)
+	$(QUESTA) vopt +acc -o vopt_tb redmule_tb -floatparameters+redmule_tb -work $(BUILD_DIR)
 
 hw-compile:
 	$(QUESTA) vsim -c +incdir+$(UVM_HOME) -do 'quit -code [source $(compile_script)]'

--- a/rtl/redmule_streamer.sv
+++ b/rtl/redmule_streamer.sv
@@ -101,19 +101,36 @@ hci_core_mux_dynamic #(
 hci_core_intf #( .DW ( DW ),
                  .UW ( UW ),
                  .EW ( EW ) ) zstream2cast ( .clk ( clk_i ) );
-hci_ecc_sink         #(
-  .MISALIGNED_ACCESSES ( REALIGN                     )
-) i_stream_ecc_sink      (
-  .clk_i               ( clk_i                       ),
-  .rst_ni              ( rst_ni                      ),
-  .test_mode_i         ( test_mode_i                 ),
-  .clear_i             ( clear_i                     ),
-  .enable_i            ( enable_i                    ),
-  .tcdm                ( zstream2cast                ),
-  .stream              ( z_stream_i                  ),
-  .ctrl_i              ( ctrl_i.z_stream_sink_ctrl   ),
-  .flags_o             ( flags_o.z_stream_sink_flags )
-);
+
+if (EW > 0) begin: gen_ecc_sink
+  hci_ecc_sink         #(
+    .MISALIGNED_ACCESSES ( REALIGN                     )
+  ) i_stream_ecc_sink      (
+    .clk_i               ( clk_i                       ),
+    .rst_ni              ( rst_ni                      ),
+    .test_mode_i         ( test_mode_i                 ),
+    .clear_i             ( clear_i                     ),
+    .enable_i            ( enable_i                    ),
+    .tcdm                ( zstream2cast                ),
+    .stream              ( z_stream_i                  ),
+    .ctrl_i              ( ctrl_i.z_stream_sink_ctrl   ),
+    .flags_o             ( flags_o.z_stream_sink_flags )
+  );
+end else begin: gen_ecc_sink
+  hci_core_sink         #(
+    .MISALIGNED_ACCESSES ( REALIGN                     )
+  ) i_stream_sink      (
+    .clk_i               ( clk_i                       ),
+    .rst_ni              ( rst_ni                      ),
+    .test_mode_i         ( test_mode_i                 ),
+    .clear_i             ( clear_i                     ),
+    .enable_i            ( enable_i                    ),
+    .tcdm                ( zstream2cast                ),
+    .stream              ( z_stream_i                  ),
+    .ctrl_i              ( ctrl_i.z_stream_sink_ctrl   ),
+    .flags_o             ( flags_o.z_stream_sink_flags )
+  );
+end
 
 // Store interface FIFO buses.
 hci_core_intf #(
@@ -307,20 +324,36 @@ for (genvar i = 0; i < NumStreamSources; i++) begin: gen_tcdm2stream
   assign load_fifo_q[i].ecc      = tcdm_cast[i].ecc;
   assign tcdm_cast[i].r_ecc      = load_fifo_q[i].r_ecc;
 
-  hci_ecc_source       #(
-    .MISALIGNED_ACCESSES ( REALIGN         )
-  ) i_stream_ecc_source      (
-    .clk_i               ( clk_i           ),
-    .rst_ni              ( rst_ni          ),
-    .test_mode_i         ( test_mode_i     ),
-    .clear_i             ( clear_i         ),
-    .enable_i            ( enable_i        ),
-    .tcdm                ( tcdm_cast[i]    ),
-    .stream              ( out_stream[i]   ),
-    .ctrl_i              ( source_ctrl[i]  ),
-    .flags_o             ( source_flags[i] )
-  );
-  
+  if (EW > 0) begin: gen_ecc_source
+    hci_ecc_source       #(
+      .MISALIGNED_ACCESSES ( REALIGN         )
+    ) i_stream_ecc_source      (
+      .clk_i               ( clk_i           ),
+      .rst_ni              ( rst_ni          ),
+      .test_mode_i         ( test_mode_i     ),
+      .clear_i             ( clear_i         ),
+      .enable_i            ( enable_i        ),
+      .tcdm                ( tcdm_cast[i]    ),
+      .stream              ( out_stream[i]   ),
+      .ctrl_i              ( source_ctrl[i]  ),
+      .flags_o             ( source_flags[i] )
+    );
+  end else begin: gen_source
+    hci_core_source       #(
+        .MISALIGNED_ACCESSES ( REALIGN         )
+      ) i_stream_source      (
+        .clk_i               ( clk_i           ),
+        .rst_ni              ( rst_ni          ),
+        .test_mode_i         ( test_mode_i     ),
+        .clear_i             ( clear_i         ),
+        .enable_i            ( enable_i        ),
+        .tcdm                ( tcdm_cast[i]    ),
+        .stream              ( out_stream[i]   ),
+        .ctrl_i              ( source_ctrl[i]  ),
+        .flags_o             ( source_flags[i] )
+      );
+  end
+
 end
 
 // Assign flags in the vector to the relative output buses.

--- a/tb/redmule_tb.sv
+++ b/tb/redmule_tb.sv
@@ -35,6 +35,8 @@ module redmule_tb;
   parameter logic [31:0] HWPE_ADDR_BASE_BIT = 20;
   parameter string STIM_INSTR = "../../stim_instr.txt";
   parameter string STIM_DATA  = "../../stim_data.txt";
+  parameter bit USE_ECC = 0;
+  parameter int unsigned EW = (USE_ECC) ? 72 : 0;
 
   // global signals
   logic clk;
@@ -56,11 +58,13 @@ module redmule_tb;
   logic [MP-1:0]       tcdm_wen;
   logic [MP-1:0][3:0]  tcdm_be;
   logic [MP-1:0][31:0] tcdm_data;
+  logic [EW-1:0]       tcdm_ecc;
   logic [MP-1:0][31:0] tcdm_r_data;
   logic [MP-1:0]       tcdm_r_valid;
   logic                tcdm_r_opc;
   logic                tcdm_r_user;
-   
+  logic [EW-1:0]       tcdm_r_ecc;
+
   logic          periph_req;
   logic          periph_gnt;
   logic [31:0]   periph_add;
@@ -161,7 +165,8 @@ module redmule_tb;
     assign tcdm[ii].add  = tcdm_add  [ii];
     assign tcdm[ii].wen  = tcdm_wen  [ii];
     assign tcdm[ii].be   = tcdm_be   [ii];
-    assign tcdm[ii].data = tcdm_data [ii];
+    if (~USE_ECC)
+      assign tcdm[ii].data = tcdm_data [ii];
     assign tcdm_gnt     [ii] = tcdm[ii].gnt;
     assign tcdm_r_data  [ii] = tcdm[ii].r_data;
     assign tcdm_r_valid [ii] = tcdm[ii].r_valid;
@@ -185,11 +190,62 @@ module redmule_tb;
                        tcdm[MP].r_valid |
                        other_r_valid    ;
 
+  if (USE_ECC) begin : gen_r_ecc
+    // RESPONSE PHASE ENCODING
+    logic [MP-1:0][38:0] tcdm_r_data_enc;
+    logic         [2:0]  tcdm_r_meta_enc;
+    for(genvar ii=0; ii<MP; ii++) begin : r_data_encoding
+      hsiao_ecc_enc #(
+        .DataWidth ( 32 )
+      ) i_r_data_enc (
+        .in  (tcdm[ii].r_data),
+        .out (tcdm_r_data_enc[ii])
+      );
+      assign tcdm_r_ecc[(ii+1)*7-1+2:ii*7+2] = tcdm_r_data_enc[ii][38:32];
+    end
+
+    hsiao_ecc_enc #(
+      .DataWidth ( 1 )
+    ) i_r_meta_enc (
+      .in  (tcdm_r_opc),
+      .out (tcdm_r_meta_enc)
+    );
+    assign tcdm_r_ecc[1:0]             = tcdm_r_meta_enc[2:1];
+    assign tcdm_r_ecc[EW-1:(7*MP+2)] = '0;
+
+  end else begin : gen_no_r_ecc
+    assign tcdm_r_ecc = '0;
+  end
+
+  if (USE_ECC) begin : gen_ecc_dec
+    // REQUEST PHASE DECODING
+    for(genvar ii=0; ii<MP; ii++) begin : data_decoding
+      hsiao_ecc_dec #(
+        .DataWidth ( 32 )
+      ) i_data_dec (
+        .in         ( { tcdm_ecc[(ii+1)*7-1+9:ii*7+9], tcdm_data[ii] } ),
+        .out        ( tcdm[ii].data ),
+        .syndrome_o ( ),
+        .err_o      ( )
+      );
+    end
+
+    hsiao_ecc_dec #(
+      .DataWidth ( 32+36+1 )
+    ) i_meta_dec (
+      .in         ( { tcdm_ecc[8:0], tcdm_add[0], tcdm_wen[0], tcdm_be } ),
+      .out        (  ),
+      .syndrome_o (  ),
+      .err_o      (  )
+    );
+  end
+
   redmule_wrap #(
     .ID_WIDTH          ( ID             ),
     .N_CORES           ( NC             ),
     .DW                ( DW             ),
-    .MP                ( DW/32          )
+    .MP                ( DW/32          ),
+    .EW                ( EW             )
   ) i_redmule_wrap     (
     .clk_i             ( clk            ),
     .rst_ni            ( rst_n          ),
@@ -201,11 +257,13 @@ module redmule_tb;
     .tcdm_wen_o        ( tcdm_wen       ),
     .tcdm_be_o         ( tcdm_be        ),
     .tcdm_data_o       ( tcdm_data      ),
+    .tcdm_ecc_o        ( tcdm_ecc       ),
     .tcdm_gnt_i        ( tcdm_gnt       ),
     .tcdm_r_data_i     ( tcdm_r_data    ),
     .tcdm_r_valid_i    ( tcdm_r_valid   ),
     .tcdm_r_opc_i      ( tcdm_r_opc     ),
     .tcdm_r_user_i     ( tcdm_r_user    ),
+    .tcdm_r_ecc_i      ( tcdm_r_ecc     ),
     .periph_req_i      ( periph_req     ),
     .periph_gnt_o      ( periph_gnt     ),
     .periph_add_i      ( periph_add     ),


### PR DESCRIPTION
This PR introduces some updates to the integration of ECC-extended HCI. It modifies the testbench allowing it to operate also in the presence of ECC-protected HCI RedMulE version. It fixes a bug related to false positives detection when data cast is performed.