### PR TITLE
Fix PULP cluster integration.

### DIFF
--- a/rtl/redmule_memory_scheduler.sv
+++ b/rtl/redmule_memory_scheduler.sv
@@ -18,6 +18,7 @@ module redmule_memory_scheduler
   input  logic                  clk_i            ,
   input  logic                  rst_ni           ,
   input  logic                  clear_i          ,
+  input  logic                  z_priority_i     ,
   input  ctrl_regfile_t         reg_file_i       ,
   input  flgs_streamer_t        flgs_streamer_i  ,
   input  cntrl_scheduler_t      cntrl_scheduler_i,
@@ -179,4 +180,5 @@ module redmule_memory_scheduler
   assign cntrl_streamer_o.output_cast_src_fmt = fpnew_pkg::fp_format_e'(reg_file_i.hwpe_params[OP_SELECTION][12:10]);
   assign cntrl_streamer_o.output_cast_dst_fmt = fpnew_pkg::fp_format_e'(reg_file_i.hwpe_params[OP_SELECTION][15:13]);
 
+  assign cntrl_streamer_o.z_priority = z_priority_i;
 endmodule : redmule_memory_scheduler

--- a/rtl/redmule_pkg.sv
+++ b/rtl/redmule_pkg.sv
@@ -121,6 +121,7 @@ package redmule_pkg;
     fpnew_pkg::fp_format_e           input_cast_dst_fmt;
     fpnew_pkg::fp_format_e           output_cast_src_fmt;
     fpnew_pkg::fp_format_e           output_cast_dst_fmt;
+    logic                            z_priority;
   } cntrl_streamer_t;
 
   typedef struct packed {
@@ -176,6 +177,7 @@ package redmule_pkg;
     logic loaded;
     logic y_ready;
     logic z_valid;
+    logic z_priority;
   } z_buffer_flgs_t;
 
   typedef struct packed {

--- a/rtl/redmule_streamer.sv
+++ b/rtl/redmule_streamer.sv
@@ -157,7 +157,7 @@ hci_core_mux_ooo #(
   .clk_i              ( clk_i                ),
   .rst_ni             ( rst_ni               ),
   .clear_i            ( clear_i              ),
-  .priority_force_i   ( '1                   ),
+  .priority_force_i   ( ctrl_i.z_priority    ),
   .priority_i         ( {1'b1, 1'b0}         ), // The z channel always has priority over the y channel
   .in                 ( yz_tcdm              ),
   .out                ( yz_tcdm_pre_r_id     )

--- a/rtl/redmule_tiler.sv
+++ b/rtl/redmule_tiler.sv
@@ -101,14 +101,17 @@ hwpe_ctrl_seq_mult #(
   .prod_o   ( x_rows_by_w_cols_iter         )
 );
 always_ff @(posedge clk_int or negedge rst_ni) begin
-  if(~rst_ni)
+  if(~rst_ni) begin
     x_rows_by_w_cols_iter_valid_q <= '0;
-  else if(clear_i | setback_i)
+    x_rows_by_w_cols_iter_valid <= '0;
+  end else if(clear_i | setback_i) begin
     x_rows_by_w_cols_iter_valid_q <= '0;
-  else
+    x_rows_by_w_cols_iter_valid <= '0;
+  end else begin
     x_rows_by_w_cols_iter_valid_q <= x_rows_by_w_cols_iter_valid_d;
+    x_rows_by_w_cols_iter_valid <= ~x_rows_by_w_cols_iter_valid_q & x_rows_by_w_cols_iter_valid_d;
+  end
 end
-assign x_rows_by_w_cols_iter_valid = ~x_rows_by_w_cols_iter_valid_q & x_rows_by_w_cols_iter_valid_d;
 
 // Sequential multiplier x_rows x w_cols x x_cols
 logic [47:0] x_rows_by_w_cols_by_x_cols_iter;

--- a/rtl/redmule_top.sv
+++ b/rtl/redmule_top.sv
@@ -138,7 +138,7 @@ flgs_scheduler_t  flgs_scheduler;
 
 // Register file binded from controller to FSM
 ctrl_regfile_t reg_file;
-flags_fifo_t   w_fifo_flgs;
+flags_fifo_t   w_fifo_flgs, z_fifo_flgs;
 cntrl_flags_t  cntrl_flags;
 
 /*--------------------------------------------------------------*/
@@ -228,7 +228,7 @@ hwpe_stream_fifo #(
   .clk_i          ( clk_i         ),
   .rst_ni         ( rst_ni        ),
   .clear_i        ( clear         ),
-  .flags_o        (               ),
+  .flags_o        ( z_fifo_flgs   ),
   .push_i         ( z_buffer_q    ),
   .pop_o          ( z_buffer_fifo )
 );
@@ -399,20 +399,22 @@ redmule_engine     #(
 /* |                    Memory Controller                      | */
 /*---------------------------------------------------------------*/
 
+logic z_priority;
+assign z_priority = z_buffer_flgs.z_priority | !z_fifo_flgs.empty;
 redmule_memory_scheduler #(
   .DW (DATAW_ALIGN),
   .W  (Width),
   .H  (Height)
 ) i_memory_scheduler (
-  .clk_i             ( clk_i                    ),
-  .rst_ni            ( rst_ni                   ),
-  .clear_i           ( clear                    ),
-  .z_priority_i      ( z_buffer_flgs.z_priority ),
-  .reg_file_i        ( reg_file                 ),
-  .flgs_streamer_i   ( flgs_streamer            ),
-  .cntrl_scheduler_i ( cntrl_scheduler          ),
-  .cntrl_flags_i     ( cntrl_flags              ),
-  .cntrl_streamer_o  ( cntrl_streamer           )
+  .clk_i             ( clk_i           ),
+  .rst_ni            ( rst_ni          ),
+  .clear_i           ( clear           ),
+  .z_priority_i      ( z_priority      ),
+  .reg_file_i        ( reg_file        ),
+  .flgs_streamer_i   ( flgs_streamer   ),
+  .cntrl_scheduler_i ( cntrl_scheduler ),
+  .cntrl_flags_i     ( cntrl_flags     ),
+  .cntrl_streamer_o  ( cntrl_streamer  )
 );
 
 

--- a/rtl/redmule_top.sv
+++ b/rtl/redmule_top.sv
@@ -114,7 +114,7 @@ end else begin: gen_xif_decoder
 end
 
 // Streamer control signals and flags
-cntrl_streamer_t cntrl_streamer;
+cntrl_streamer_t cntrl_streamer_int, cntrl_streamer;
 flgs_streamer_t  flgs_streamer;
 
 cntrl_engine_t   cntrl_engine;
@@ -404,14 +404,15 @@ redmule_memory_scheduler #(
   .W  (Width),
   .H  (Height)
 ) i_memory_scheduler (
-  .clk_i             ( clk_i               ),
-  .rst_ni            ( rst_ni              ),
-  .clear_i           ( clear               ),
-  .reg_file_i        ( reg_file            ),
-  .flgs_streamer_i   ( flgs_streamer       ),
-  .cntrl_scheduler_i ( cntrl_scheduler     ),
-  .cntrl_flags_i     ( cntrl_flags         ),
-  .cntrl_streamer_o  ( cntrl_streamer      )
+  .clk_i             ( clk_i                    ),
+  .rst_ni            ( rst_ni                   ),
+  .clear_i           ( clear                    ),
+  .z_priority_i      ( z_buffer_flgs.z_priority ),
+  .reg_file_i        ( reg_file                 ),
+  .flgs_streamer_i   ( flgs_streamer            ),
+  .cntrl_scheduler_i ( cntrl_scheduler          ),
+  .cntrl_flags_i     ( cntrl_flags              ),
+  .cntrl_streamer_o  ( cntrl_streamer           )
 );
 
 

--- a/rtl/z_buffer/redmule_z_buffer.sv
+++ b/rtl/z_buffer/redmule_z_buffer.sv
@@ -47,6 +47,9 @@ logic [$clog2(W)-1:0] store_shift_d, store_shift_q, w_index;
 
 logic load_en, store_en;
 
+logic [$clog2(TOT_DEPTH):0] z_height_tmp;
+logic [$clog2(TOT_DEPTH)-1:0] z_height;
+
 redmule_z_buffer_scm #(
   .WORD_SIZE ( BITW ),
   .ROWS      ( D    ),
@@ -216,10 +219,12 @@ always_comb begin : reset_depth_counter
   end
 end
 
+assign z_height_tmp = ctrl_i.z_height - 'd1;
+assign z_height = z_height_tmp[$clog2(TOT_DEPTH)-1:0];
+
 always_comb begin : z_strb_assignment
   z_strb_o = '0;
-
-  for (int i = 0; i < ctrl_i.z_height; i++) begin
+  for (int i = 0; i <= z_height; i++) begin
     z_strb_o[i*BITW/8+:BITW/8] = '1;
   end
 end

--- a/rtl/z_buffer/redmule_z_buffer.sv
+++ b/rtl/z_buffer/redmule_z_buffer.sv
@@ -123,7 +123,7 @@ end
 
 // With very small leftovers on K it may happen that the z submatrix is completely stored before the current matrix of biases is fully pushed.
 // Therefore, we have to check that we are not in the process of pushing biases into the array before storing
-assign load_en  = current_state == EMPTY && ~ctrl_i.fill && d_index == '0;
+assign load_en  = current_state == EMPTY && ~ctrl_i.fill && d_index == '0 && fill_shift == '0;
 assign store_en = current_state == PUSHED;
 
 // Counter to track when the output buffer is full

--- a/rtl/z_buffer/redmule_z_buffer.sv
+++ b/rtl/z_buffer/redmule_z_buffer.sv
@@ -71,6 +71,7 @@ redmule_z_buffer_scm #(
 
 assign flags_o.y_ready = load_en && ctrl_i.y_valid;
 assign flags_o.z_valid = store_en && ctrl_i.ready;
+assign flags_o.z_priority = store_en;
 
 always_ff @(posedge clk_i or negedge rst_ni) begin  : state_register
   if(~rst_ni) begin


### PR DESCRIPTION
This PR proposes a few changes to make RedMulE v2 work into PULP cluster. In particular:
* Makes the YZ OoO mux priority dynamic and asserted only while the Z buffer stores or the Z fifo is not empty.
* Fixes an error in the tiler which was sampling a multiplier valid one cycle in advance,