### PR TITLE
[fix] Stallable interface verification was broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.bender**
+golden-model/venv/**
+**/build/**
+target/sim/vsim/**
+!target/sim/vsim/vsim.mk
+!target/sim/vsim/wave.tcl
+vendor/**
+**.pyc
+golden-model/*/txt/*.txt
+sw/inc/**

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ gui      ?= 0
 ipstools ?= 0
 P_STALL  ?= 0.0
 
+common_defs += -D PROB_STALL=${P_STALL}
+
 ifeq ($(verbose),1)
 	FLAGS += -DVERBOSE
 endif
@@ -121,9 +123,9 @@ dis:
 
 OP     ?= gemm
 fp_fmt ?= FP16
-M      ?= 24
-N      ?= 16
-K      ?= 16
+M      ?= 32
+N      ?= 32
+K      ?= 32
 
 golden: golden-clean
 	$(MAKE) -C golden-model $(OP) SW=$(SW)/inc M=$(M) N=$(N) K=$(K) fp_fmt=$(fp_fmt)

--- a/target/sim/src/redmule_tb.sv
+++ b/target/sim/src/redmule_tb.sv
@@ -14,7 +14,8 @@ module redmule_tb
 #(
   parameter TCP = 1.0ns, // clock period, 1 GHz clock
   parameter TA  = 0.2ns, // application time
-  parameter TT  = 0.8ns  // test time
+  parameter TT  = 0.8ns,  // test time
+  parameter real PROB_STALL
 )(
   input logic clk_i,
   input logic rst_ni,
@@ -22,7 +23,6 @@ module redmule_tb
 );
 
   // parameters
-  localparam int unsigned PROB_STALL = 0;
   localparam int unsigned NC = 1;
   localparam int unsigned ID = 10;
   localparam int unsigned DW = redmule_pkg::DATA_W;

--- a/target/sim/src/redmule_tb_wrap.sv
+++ b/target/sim/src/redmule_tb_wrap.sv
@@ -13,13 +13,15 @@ import redmule_pkg::*;
   localparam TCP = 1.0ns; // clock period, 1 GHz clock
   localparam TA  = 0.2ns; // application time
   localparam TT  = 0.8ns; // test time
+  parameter real PROB_STALL = `PROB_STALL;
 
   logic clk, rst_n, fetch_enable;
 
   redmule_tb #(
-    .TCP ( TCP ),
-    .TA  ( TA  ),
-    .TT  ( TT  ) 
+    .TCP       ( TCP        ),
+    .TA        ( TA         ),
+    .TT        ( TT         ) ,
+    .PROB_STALL( PROB_STALL )
   ) i_redmule_tb (
     .clk_i          ( clk          ),
     .rst_ni         ( rst_n        ),


### PR DESCRIPTION
As discussed with @belanoa creating this PR
1. The P_STALL parameter from the Makefile was not propagated to the testbench
2. The PROB_STALL inside the testbench was not working due to type mismatch. This commit fixes the P_STALL parameter by propagating from Makefile to the data memory. It uncovers the interface issues which was hidden due to incorrect parameter propagation