### PR TITLE
Add ECC-extended HCI fault-counting memory-mapped registers.

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -1,4 +1,20 @@
 packages:
+  apb:
+    revision: 77ddf073f194d44b9119949d2421be59789e69ae
+    version: 0.2.4
+    source:
+      Git: https://github.com/pulp-platform/apb.git
+    dependencies:
+    - common_cells
+  axi:
+    revision: 2f395b176bee1c769c80f060a4345fda965bb04b
+    version: 0.38.0
+    source:
+      Git: https://github.com/pulp-platform/axi.git
+    dependencies:
+    - common_cells
+    - common_verification
+    - tech_cells_generic
   cluster_interconnect:
     revision: 1284def6c0b7f7e9355eb093d00883ad9dead1b7
     version: null
@@ -51,14 +67,17 @@ packages:
     dependencies:
     - common_cells
   hci:
-    revision: 06fcba671e060f2e1b03b7ebe2d3e719f1557099
+    revision: 8408a6d7a7a4d814dcb3468934e49b407b1c783e
     version: null
     source:
       Git: https://github.com/pulp-platform/hci.git
     dependencies:
     - cluster_interconnect
+    - common_cells
     - hwpe-stream
     - l2_tcdm_hybrid_interco
+    - redundancy_cells
+    - register_interface
   hwpe-ctrl:
     revision: 3690a3c648f120546d8de2bc583d5170c36d2f20
     version: null
@@ -94,6 +113,25 @@ packages:
     dependencies:
     - common_cells
     - common_verification
+  redundancy_cells:
+    revision: c37bdb47339bf70e8323de8df14ea8bbeafb6583
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/redundancy_cells.git
+    dependencies:
+    - common_cells
+    - common_verification
+    - register_interface
+    - tech_cells_generic
+  register_interface:
+    revision: 146501d80052b61475cdc333d3aab4cd769fd5dc
+    version: 0.3.9
+    source:
+      Git: https://github.com/pulp-platform/register_interface.git
+    dependencies:
+    - apb
+    - axi
+    - common_cells
   tech_cells_generic:
     revision: 7968dd6e6180df2c644636bc6d2908a49f2190cf
     version: 0.2.13

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,11 +17,12 @@ dependencies:
   ibex              : { git: "https://github.com/pulp-platform/ibex.git"              , rev: pulpissimo-v6.1.2   }
   hwpe-stream       : { git: "https://github.com/pulp-platform/hwpe-stream.git"       , version: =1.9.0          }
   hwpe-ctrl         : { git: "https://github.com/pulp-platform/hwpe-ctrl.git"         , rev: "3690a3c"           } # master
-  hci               : { git: "https://github.com/pulp-platform/hci.git"               , rev: "06fcba6"           } # main
+  hci               : { git: "https://github.com/pulp-platform/hci.git"               , rev: "8408a6d"           } # master
   fpnew             : { git: "https://github.com/pulp-platform/cvfpu.git"             , rev: "pulp-v0.1.3"       }
   common_cells      : { git: "https://github.com/pulp-platform/common_cells.git"      , version: =1.38.0         }
   obi               : { git: "https://github.com/pulp-platform/obi.git"               , version: =0.1.6          }
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: =0.2.13         }
+  register_interface: { git: "https://github.com/pulp-platform/register_interface.git", version: 0.3.1           }
 
 sources:
   files:

--- a/rtl/redmule_ctrl.sv
+++ b/rtl/redmule_ctrl.sv
@@ -6,16 +6,19 @@
 // Andrea Belano <andrea.belano2@unibo.it>
 //
 
+
 import redmule_pkg::*;
 
 module redmule_ctrl
   import hwpe_ctrl_package::*;
+  import hci_package::*;
 #(
   parameter  int unsigned N_CORES       = 8                      ,
   parameter  int unsigned IO_REGS       = REDMULE_REGS           ,
   parameter  int unsigned ID_WIDTH      = 8                      ,
   parameter  int unsigned SysDataWidth  = 32                     ,
   parameter  int unsigned N_CONTEXT     = 2                      ,
+  parameter  int unsigned HCI_ECC       = 0                      ,
   parameter  int unsigned Height        = 4                      ,
   parameter  int unsigned Width         = 8                      ,
   parameter  int unsigned NumPipeRegs   = 3                      ,
@@ -39,6 +42,8 @@ module redmule_ctrl
   // Control signals for the state machine
   output cntrl_scheduler_t        cntrl_scheduler_o ,
   output cntrl_flags_t            cntrl_flags_o,
+  // ECC error signals
+  input errs_streamer_t           errs_streamer_i   ,
   // Peripheral slave port
   hwpe_ctrl_intf_periph.slave     periph
 );
@@ -60,6 +65,8 @@ module redmule_ctrl
   hwpe_ctrl_package::ctrl_slave_t   cntrl_slave;
   hwpe_ctrl_package::flags_slave_t  flgs_slave;
 
+  hwpe_ctrl_intf_periph   #( .ID_WIDTH ( ID_WIDTH ) ) periph_slave ( .clk( clk_i ) );
+
   // Control slave interface
   hwpe_ctrl_slave  #(
     .REGFILE_SCM    ( 0            ),
@@ -72,7 +79,7 @@ module redmule_ctrl
     .clk_i          ( clk_i        ),
     .rst_ni         ( rst_ni       ),
     .clear_o        ( clear        ),
-    .cfg            ( periph       ),
+    .cfg            ( periph_slave ),
     .ctrl_i         ( cntrl_slave  ),
     .flags_o        ( flgs_slave   ),
     .reg_file       ( reg_file_d   )
@@ -90,6 +97,101 @@ module redmule_ctrl
   );
 
   assign cfg_complete_o = tiler_valid;
+  /*---------------------------------------------------------------------------------------------*/
+  /*                                       ECC Register island                                   */
+  /*---------------------------------------------------------------------------------------------*/
+  if (HCI_ECC) begin : gen_ecc_manager
+    hwpe_ctrl_intf_periph   #( .ID_WIDTH ( ID_WIDTH ) ) periph_ecc ( .clk( clk_i ) );
+
+    hci_ecc_req_t hci_ecc_req;
+    hci_ecc_rsp_t hci_ecc_rsp;
+
+    logic periph_ecc_redirect, periph_ecc_redirect_q;
+
+    assign periph_ecc_redirect = ((periph.add[7:4] == HCI_ECC_MASK) && periph.req) ? 1 : 0;
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if(~rst_ni) begin
+        periph_ecc_redirect_q <= 1'b0;
+      end else begin
+        if (clear)
+            periph_ecc_redirect_q <= 1'b0;
+        else
+            periph_ecc_redirect_q <= periph_ecc_redirect;
+      end
+    end
+
+    // Periph port binding
+    always_comb begin
+      periph_slave.req  = periph.req;
+      periph_slave.add  = periph.add;
+      periph_slave.wen  = periph.wen;
+      periph_slave.be   = periph.be;
+      periph_slave.data = periph.data;
+      periph_slave.id   = periph.id;
+      periph_ecc.req    = (periph_ecc_redirect)   ? periph.req         : '0;
+      periph_ecc.add    = (periph_ecc_redirect)   ? periph.add         : '0;
+      periph_ecc.wen    = (periph_ecc_redirect)   ? periph.wen         : '0;
+      periph_ecc.be     = (periph_ecc_redirect)   ? periph.be          : '0;
+      periph_ecc.data   = (periph_ecc_redirect)   ? periph.data        : '0;
+      periph_ecc.id     = (periph_ecc_redirect)   ? periph.id          : '0;
+      periph.gnt        = (periph_ecc_redirect)   ? periph_ecc.gnt     : periph_slave.gnt;
+      periph.r_data     = (periph_ecc_redirect_q) ? periph_ecc.r_data  : periph_slave.r_data;
+      periph.r_valid    = (periph_ecc_redirect_q) ? periph_ecc.r_valid : periph_slave.r_valid;
+      periph.r_id       = (periph_ecc_redirect)   ? periph_ecc.r_id    : periph_slave.r_id;
+    end
+
+    periph_to_reg #(
+      .IW             ( ID_WIDTH           ),
+      .req_t          ( hci_ecc_req_t      ),
+      .rsp_t          ( hci_ecc_rsp_t      )
+    ) i_periph_to_ecc_reg (
+      .clk_i          ( clk_i              ),
+      .rst_ni         ( rst_ni             ),
+      .req_i          ( periph_ecc.req     ),
+      .add_i          ( periph_ecc.add     ),
+      .wen_i          ( periph_ecc.wen     ),
+      .wdata_i        ( periph_ecc.data    ),
+      .be_i           ( periph_ecc.be      ),
+      .id_i           ( periph_ecc.id      ),
+      .gnt_o          ( periph_ecc.gnt     ),
+      .r_rdata_o      ( periph_ecc.r_data  ),
+      .r_opc_o        (                    ),
+      .r_id_o         ( periph_ecc.r_id    ),
+      .r_valid_o      ( periph_ecc.r_valid ),
+      .reg_req_o      ( hci_ecc_req        ),
+      .reg_rsp_i      ( hci_ecc_rsp        )
+    );
+
+    hci_ecc_manager #(
+      .N_CHUNK        ( ECC_N_CHUNK ),
+      .PAR_DATA       ( 1           ),
+      .PAR_META       ( 1           )
+    ) i_hci_ecc_manager (
+      .clk_i                    ( clk_i                             ),
+      .rst_ni                   ( rst_ni                            ),
+      .hci_ecc_req_i            ( hci_ecc_req                       ),
+      .hci_ecc_rsp_o            ( hci_ecc_rsp                       ),
+      .data_correctable_err_i   ( errs_streamer_i.data_single_err   ),
+      .data_uncorrectable_err_i ( errs_streamer_i.data_multi_err    ),
+      .meta_correctable_err_i   ( errs_streamer_i.meta_single_err   ),
+      .meta_uncorrectable_err_i ( errs_streamer_i.meta_multi_err    )
+    );
+  end else begin : gen_periph_slave
+    always_comb begin
+      periph_slave.req  = periph.req;
+      periph_slave.add  = periph.add;
+      periph_slave.wen  = periph.wen;
+      periph_slave.be   = periph.be;
+      periph_slave.data = periph.data;
+      periph_slave.id   = periph.id;
+      periph.gnt        = periph_slave.gnt;
+      periph.r_data     = periph_slave.r_data;
+      periph.r_valid    = periph_slave.r_valid;
+      periph.r_id       = periph_slave.r_id;
+    end
+  end
+
   /*---------------------------------------------------------------------------------------------*/
   /*                                       Register island                                       */
   /*---------------------------------------------------------------------------------------------*/

--- a/rtl/redmule_pkg.sv
+++ b/rtl/redmule_pkg.sv
@@ -86,6 +86,8 @@ package redmule_pkg;
   // [0:0]   -> GEMM selection
   parameter int unsigned OP_SELECTION = 17; // 0x44
 
+  parameter int unsigned HCI_ECC_MASK = 4'b1001; // 0x90-0x9C
+
   parameter bit[6:0] MCNFIG = 7'b0001011; // 0x0B
   parameter bit[6:0] MARITH = 7'b0101011; // 0x2B
   parameter bit[6:0] RVCSR  = 7'b1110011; // 0x73 -> RISC-V CSR instruction opcode
@@ -316,5 +318,12 @@ package redmule_pkg;
     logic r_opc;
     logic r_user;
   } redmule_default_data_rsp_t;
+
+  typedef struct packed {
+    logic [ECC_N_CHUNK-1:0] data_single_err;
+    logic [ECC_N_CHUNK-1:0] data_multi_err;
+    logic                   meta_single_err;
+    logic                   meta_multi_err;
+  } errs_streamer_t;
 
 endpackage

--- a/rtl/redmule_streamer.sv
+++ b/rtl/redmule_streamer.sv
@@ -33,6 +33,8 @@ module redmule_streamer
   // TCDM interface between the streamer and the memory
   hci_core_intf.initiator        tcdm      ,
 
+  // ECC error signals
+  output errs_streamer_t         ecc_errors_o,
   // Control signals
   input  cntrl_streamer_t        ctrl_i,
   output flgs_streamer_t         flags_o
@@ -119,8 +121,14 @@ if (EW > 1) begin : gen_ecc_encoder
     .tcdm_target         ( ldst_tcdm       ),
     .tcdm_initiator      ( tcdm            )
   );
+
+  assign ecc_errors_o.data_single_err = data_single_err & {ECC_N_CHUNK{tcdm.r_valid}};
+  assign ecc_errors_o.data_multi_err  = data_multi_err  & {ECC_N_CHUNK{tcdm.r_valid}};
+  assign ecc_errors_o.meta_single_err = meta_single_err & tcdm.r_valid;
+  assign ecc_errors_o.meta_multi_err  = meta_multi_err  & tcdm.r_valid;
 end else begin : gen_ldst_assign
   hci_core_assign i_ldst_assign ( .tcdm_target (ldst_tcdm), .tcdm_initiator (tcdm) );
+  assign ecc_errors_o = '0;
 end
 
 // Virtual internal TCDM interface used by the y and z channels

--- a/sw/archi_redmule.h
+++ b/sw/archi_redmule.h
@@ -78,6 +78,13 @@
 #define REDMULE_MCFG1_PTR 0x10
 #define REDMULE_ARITH_PTR 0x14
 
+// ECC Registers
+#define REDMULE_ECC_REG_OFFS 0x90
+#define DATA_CORR_ERR 0x00
+#define DATA_UNCORR_ERR 0x04
+#define METADATA_CORR_ERR 0x08
+#define METADATA_UNCORR_ERR 0x0c
+
 // OPs definition
 #define MATMUL 0x0
 #define GEMM 0x1

--- a/sw/hal_redmule.h
+++ b/sw/hal_redmule.h
@@ -38,6 +38,22 @@ static inline void redmule_arith_set(uint32_t arith) {
   HWPE_WRITE(arith, REDMULE_REG_OFFS + REDMULE_ARITH_PTR);
 }
 
+static inline unsigned int redmule_get_data_correctable_count() {
+  return HWPE_READ(REDMULE_ECC_REG_OFFS + DATA_CORR_ERR);
+}
+
+static inline unsigned int redmule_get_data_uncorrectable_count() {
+  return HWPE_READ(REDMULE_ECC_REG_OFFS + DATA_UNCORR_ERR);
+}
+
+static inline unsigned int redmule_get_meta_correctable_count() {
+  return HWPE_READ(REDMULE_ECC_REG_OFFS + METADATA_CORR_ERR);
+}
+
+static inline unsigned int redmule_get_meta_uncorrectable_count() {
+  return HWPE_READ(REDMULE_ECC_REG_OFFS + METADATA_UNCORR_ERR);
+}
+
 static inline void hwpe_trigger_job() { HWPE_WRITE(0, REDMULE_TRIGGER); }
 
 static inline int hwpe_acquire_job() { return HWPE_READ(REDMULE_ACQUIRE); }


### PR DESCRIPTION
This PR adds ECC-extended memory-mapped registers for counting HCI faults.
All credits to @LuigiGhionda !