### PR TITLE
Fix leftover cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   run-hwpe-tests:
     name: run-hwpe-tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       N_PROC: 8
       Target: verilator
@@ -57,6 +59,16 @@ jobs:
     - name: Run Tests
       run: |
         scripts/regression-list.sh
+
+    - name: Store benchmark result
+      if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: Execution cycles
+        tool: customSmallerIsBetter
+        output-file-path: scripts/perf.json
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-push: true
 
   # run-complex-tests:
   #   name: run-complex-tests

--- a/Bender.lock
+++ b/Bender.lock
@@ -67,8 +67,8 @@ packages:
     dependencies:
     - common_cells
   hci:
-    revision: 9095c8522576c4c19d13e88163029b0c35f371e0
-    version: 2.6.0
+    revision: a8d8132b7f7839fd55f92df65cdc3e361ea80a6b
+    version: 2.6.1
     source:
       Git: https://github.com/pulp-platform/hci.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,7 +17,7 @@ dependencies:
   ibex              : { git: "https://github.com/pulp-platform/ibex.git"              , rev: pulpissimo-v6.1.2                        }
   hwpe-stream       : { git: "https://github.com/pulp-platform/hwpe-stream.git"       , version: 1.9.2                                }
   hwpe-ctrl         : { git: "https://github.com/pulp-platform/hwpe-ctrl.git"         , version: 3.1.0                                } 
-  hci               : { git: "https://github.com/pulp-platform/hci.git"               , version: 2.3.0                                }
+  hci               : { git: "https://github.com/pulp-platform/hci.git"               , version: 2.6.1                                }
   fpnew             : { git: "https://github.com/pulp-platform/cvfpu.git"             , rev: "pulp-v0.1.3"                            }
   common_cells      : { git: "https://github.com/pulp-platform/common_cells.git"      , version: 1.21.0                               }
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.11                               }

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ STIM_DATA=$(BUILD_DIR)/stim_data.txt
 
 # Build implicit rules
 $(STIM_INSTR) $(STIM_DATA): $(BIN)
-	objcopy --srec-len 1 --output-target=srec $(BIN) $(BIN).s19
+	$(Gcc)$(ISA)$(XLEN)-unknown-elf-objcopy --srec-len 1 --output-target=srec $(BIN) $(BIN).s19
 	$(PYTHON) scripts/parse_s19.py < $(BIN).s19 > $(BIN).txt
 	$(PYTHON) scripts/s19tomem.py $(BIN).txt $(STIM_INSTR) $(STIM_DATA)
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The `tb/redmule_complex_tb.sv` provides an implementatio of a complex core as an
 
 ![](doc/redmule_complex_testbench.png)
 
+### Performance benchmarks
+Every regression run measures the HWPE job duration (in clock cycles) for each tested M/N/K configuration. On every push to `devel`, these results are published as historical trend charts at [pulp-platform.github.io/redmule/dev/bench](https://pulp-platform.github.io/redmule/dev/bench/).
+
 ## Programming model
 RedMulE is designed to reduce the effort required for the matrix multiplication tiling to the minimum. It features an internal hardware unit called "tiler" that needs very reduced input information (i.e. tesors dimensions, computing format, pointers to the input/output tensors and the operation to perform). Then, it is in charge of autonomously calculate the tiling of the tensors.
 ### HWPE memory-mapped programming

--- a/rtl/redmule_scheduler.sv
+++ b/rtl/redmule_scheduler.sv
@@ -385,10 +385,21 @@ module redmule_scheduler
   redmule_config_t y_config_fast;
   logic            y_config_fast_empty, y_config_fast_full;
 
+  // Dedicated store-side (Z) tiling config, retired only when the last Z store
+  // retires (see i_z_config_fast_fifo) so the store geometry stays valid through
+  // the final leftover-K store burst.
+  redmule_config_t z_config_fast;
+  logic            z_config_fast_empty, z_config_fast_full;
+
   logic [15:0]                    y_cols_iter_d, y_cols_iter_q,
                                   y_rows_iter_d, y_rows_iter_q;
 
   logic                           y_cols_iter_en, y_rows_iter_en;
+
+  logic [15:0]                    z_cols_iter_d, z_cols_iter_q,
+                                  z_rows_iter_d, z_rows_iter_q;
+
+  logic                           z_cols_iter_en, z_rows_iter_en;
 
   logic [$clog2(NumPipeRegs+1)-1:0] z_wait_counter_d, z_wait_counter_q;
   logic [$clog2(D)-1:0]           z_avail_counter_d, z_avail_counter_q,
@@ -402,8 +413,8 @@ module redmule_scheduler
                                   z_avail_en, z_avail_clr,
                                   y_push_en, y_push_clr;
 
-  logic [$clog2(W):0]             y_width, z_width;
-  logic [$clog2(D):0]             y_height, z_height;
+  logic [$clog2(W):0]             y_width, z_width, z_width_next;
+  logic [$clog2(D):0]             y_height, z_height, z_height_next;
 
   logic y_config_pop;
   assign y_config_pop = y_rows_iter_q == y_config.x_rows_iter-1 && y_rows_iter_en && ~y_config_empty;
@@ -443,6 +454,29 @@ module redmule_scheduler
     .push_i     ( config_valid_i      ),
     .data_o     ( y_config_fast       ),
     .pop_i      ( y_config_fast_pop   )
+  );
+
+  // Store-side config FIFO: same contents as the others but retired on the last
+  // Z store (z_config_fast_pop), i.e. one tile later than y_config_fast (last Y
+  // load), so the leftover-K geometry is still valid when the final tile stores.
+  logic z_config_fast_pop;
+  assign z_config_fast_pop = z_rows_iter_q == z_config_fast.x_rows_iter-1 && z_rows_iter_en && ~z_config_fast_empty;
+  redmule_config_fifo #(
+    .FALL_THROUGH (0),
+    .DEPTH (2),
+    .dtype (redmule_config_t)
+  ) i_z_config_fast_fifo (
+    .clk_i      ( clk_i               ),
+    .rst_ni     ( rst_ni              ),
+    .flush_i    ( clear_i             ),
+    .testmode_i ( '0                  ),
+    .full_o     ( z_config_fast_full  ),
+    .empty_o    ( z_config_fast_empty ),
+    .usage_o    (                     ),
+    .data_i     ( config_i            ),
+    .push_i     ( config_valid_i      ),
+    .data_o     ( z_config_fast       ),
+    .pop_i      ( z_config_fast_pop   )
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : y_pushed_register
@@ -500,6 +534,40 @@ module redmule_scheduler
 
   assign y_rows_iter_en = y_cols_iter_q == y_config.w_cols_iter-1 && y_cols_iter_en;
   assign y_rows_iter_d  = y_rows_iter_q == y_config.x_rows_iter-1 ? '0 : y_rows_iter_q + 1;
+
+  // Store-side (Z) tile iterators. Mirror the Y iterators (advance on the same
+  // store-completion pulse flgs_z_buffer_i.empty) but are bounded by, and index
+  // into, the store-lifetime z_config_fast so the store geometry never reads a
+  // config that was retired by the leading load pipeline.
+  always_ff @(posedge clk_i or negedge rst_ni) begin : z_columns_iteration
+    if(~rst_ni) begin
+      z_cols_iter_q <= '0;
+    end else begin
+      if (clear_i || cntrl_scheduler_i.rst) begin
+        z_cols_iter_q <= '0;
+      end else if (z_cols_iter_en) begin
+        z_cols_iter_q <= z_cols_iter_d;
+      end
+    end
+  end
+
+  assign z_cols_iter_en = flgs_z_buffer_i.empty;
+  assign z_cols_iter_d  = z_cols_iter_q == z_config_fast.w_cols_iter-1 ? '0 : z_cols_iter_q + 1;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : z_rows_iteration
+    if(~rst_ni) begin
+      z_rows_iter_q <= '0;
+    end else begin
+      if (clear_i || cntrl_scheduler_i.rst) begin
+        z_rows_iter_q <= '0;
+      end else if (z_rows_iter_en) begin
+        z_rows_iter_q <= z_rows_iter_d;
+      end
+    end
+  end
+
+  assign z_rows_iter_en = z_cols_iter_q == z_config_fast.w_cols_iter-1 && z_cols_iter_en;
+  assign z_rows_iter_d  = z_rows_iter_q == z_config_fast.x_rows_iter-1 ? '0 : z_rows_iter_q + 1;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : z_wait_enable_register
     if(~rst_ni) begin
@@ -585,6 +653,12 @@ module redmule_scheduler
   assign y_width  = y_rows_iter_q == y_config_fast.w_rows_iter-1 && y_config_fast.w_rows_lftovr != '0 ? y_config_fast.w_rows_lftovr : W;
   assign y_height = y_cols_iter_q == y_config_fast.w_cols_iter-1 && y_config_fast.w_cols_lftovr != '0 ? y_config_fast.w_cols_lftovr : D;
 
+  // Store-side geometry: identical formula to y_width/y_height above, but driven
+  // by the store iterators + z_config_fast so the last leftover-K store latches
+  // the correct (leftover) width instead of a stale full width.
+  assign z_width_next  = z_rows_iter_q == z_config_fast.w_rows_iter-1 && z_config_fast.w_rows_lftovr != '0 ? z_config_fast.w_rows_lftovr : W;
+  assign z_height_next = z_cols_iter_q == z_config_fast.w_cols_iter-1 && z_config_fast.w_cols_lftovr != '0 ? z_config_fast.w_cols_lftovr : D;
+
   always_ff @(posedge clk_i or negedge rst_ni) begin : z_width_register
     if(~rst_ni) begin
       z_width <= '0;
@@ -592,7 +666,7 @@ module redmule_scheduler
       if (clear_i || cntrl_scheduler_i.rst) begin
         z_width <= '0;
       end else if (flgs_z_buffer_i.empty || start_computation) begin
-        z_width <= y_width;
+        z_width <= z_width_next;
       end
     end
   end
@@ -604,7 +678,7 @@ module redmule_scheduler
       if (clear_i || cntrl_scheduler_i.rst) begin
         z_height <= '0;
       end else if (flgs_z_buffer_i.empty || start_computation) begin
-        z_height <= y_height;
+        z_height <= z_height_next;
       end
     end
   end

--- a/rtl/redmule_scheduler.sv
+++ b/rtl/redmule_scheduler.sv
@@ -415,6 +415,7 @@ module redmule_scheduler
 
   logic [$clog2(W):0]             y_width, z_width, z_width_next;
   logic [$clog2(D):0]             y_height, z_height, z_height_next;
+  logic [$clog2(D):0]             y_push_height;
 
   logic y_config_pop;
   assign y_config_pop = y_rows_iter_q == y_config.x_rows_iter-1 && y_rows_iter_en && ~y_config_empty;
@@ -647,8 +648,26 @@ module redmule_scheduler
     end
   end
 
-  assign y_push_counter_d = y_push_counter_q == y_height-1 ? '0 : y_push_counter_q + 1;
-  assign y_push_clr       = y_push_en && ~stall_engine && y_push_counter_q == y_height-1;
+  // Latch the bias-push height at the start of each push and hold it stable for
+  // the whole push. y_height is combinational off the store-timed y_cols_iter_q,
+  // which can advance (on a store-empty) *mid-push* — most visibly with a small
+  // trailing K-leftover under N-tiling, where it flips D->w_cols_lftovr partway
+  // through a full tile's push and makes the counter overshoot, injecting extra
+  // bias columns into the next tile. Latching pins it to the current push's tile.
+  always_ff @(posedge clk_i or negedge rst_ni) begin : y_push_height_register
+    if (~rst_ni) begin
+      y_push_height <= '0;
+    end else begin
+      if (clear_i || cntrl_scheduler_i.rst) begin
+        y_push_height <= '0;
+      end else if ((z_wait_en && ~stall_engine && z_wait_counter_q == NumPipeRegs-1) || start_computation) begin
+        y_push_height <= y_height;
+      end
+    end
+  end
+
+  assign y_push_counter_d = y_push_counter_q == y_push_height-1 ? '0 : y_push_counter_q + 1;
+  assign y_push_clr       = y_push_en && ~stall_engine && y_push_counter_q == y_push_height-1;
 
   assign y_width  = y_rows_iter_q == y_config_fast.w_rows_iter-1 && y_config_fast.w_rows_lftovr != '0 ? y_config_fast.w_rows_lftovr : W;
   assign y_height = y_cols_iter_q == y_config_fast.w_cols_iter-1 && y_config_fast.w_cols_lftovr != '0 ? y_config_fast.w_cols_lftovr : D;
@@ -692,7 +711,7 @@ module redmule_scheduler
   assign cntrl_z_buffer_o.mask_y        = y_config_fast.gemm_selection;
 
   assign cntrl_z_buffer_o.y_width       = y_width;
-  assign cntrl_z_buffer_o.y_height      = y_height;
+  assign cntrl_z_buffer_o.y_height      = y_push_height;
   assign cntrl_z_buffer_o.z_width       = z_width;
   assign cntrl_z_buffer_o.z_height      = z_height;
 

--- a/rtl/redmule_scheduler.sv
+++ b/rtl/redmule_scheduler.sv
@@ -386,8 +386,7 @@ module redmule_scheduler
   logic            y_config_fast_empty, y_config_fast_full;
 
   // Dedicated store-side (Z) tiling config, retired only when the last Z store
-  // retires (see i_z_config_fast_fifo) so the store geometry stays valid through
-  // the final leftover-K store burst.
+  // retires
   redmule_config_t z_config_fast;
   logic            z_config_fast_empty, z_config_fast_full;
 
@@ -457,9 +456,9 @@ module redmule_scheduler
     .pop_i      ( y_config_fast_pop   )
   );
 
-  // Store-side config FIFO: same contents as the others but retired on the last
-  // Z store (z_config_fast_pop), i.e. one tile later than y_config_fast (last Y
-  // load), so the leftover-K geometry is still valid when the final tile stores.
+  // Store-side config FIFO: retired on the last Z store (z_config_fast_pop), i.e.
+  // one tile later than y_config_fast (last Y load), so the leftover-K config is
+  // still valid when the final tile stores.
   logic z_config_fast_pop;
   assign z_config_fast_pop = z_rows_iter_q == z_config_fast.x_rows_iter-1 && z_rows_iter_en && ~z_config_fast_empty;
   redmule_config_fifo #(
@@ -648,12 +647,6 @@ module redmule_scheduler
     end
   end
 
-  // Latch the bias-push height at the start of each push and hold it stable for
-  // the whole push. y_height is combinational off the store-timed y_cols_iter_q,
-  // which can advance (on a store-empty) *mid-push* — most visibly with a small
-  // trailing K-leftover under N-tiling, where it flips D->w_cols_lftovr partway
-  // through a full tile's push and makes the counter overshoot, injecting extra
-  // bias columns into the next tile. Latching pins it to the current push's tile.
   always_ff @(posedge clk_i or negedge rst_ni) begin : y_push_height_register
     if (~rst_ni) begin
       y_push_height <= '0;
@@ -672,9 +665,6 @@ module redmule_scheduler
   assign y_width  = y_rows_iter_q == y_config_fast.w_rows_iter-1 && y_config_fast.w_rows_lftovr != '0 ? y_config_fast.w_rows_lftovr : W;
   assign y_height = y_cols_iter_q == y_config_fast.w_cols_iter-1 && y_config_fast.w_cols_lftovr != '0 ? y_config_fast.w_cols_lftovr : D;
 
-  // Store-side geometry: identical formula to y_width/y_height above, but driven
-  // by the store iterators + z_config_fast so the last leftover-K store latches
-  // the correct (leftover) width instead of a stale full width.
   assign z_width_next  = z_rows_iter_q == z_config_fast.w_rows_iter-1 && z_config_fast.w_rows_lftovr != '0 ? z_config_fast.w_rows_lftovr : W;
   assign z_height_next = z_cols_iter_q == z_config_fast.w_cols_iter-1 && z_config_fast.w_cols_lftovr != '0 ? z_config_fast.w_cols_lftovr : D;
 

--- a/rtl/redmule_streamer.sv
+++ b/rtl/redmule_streamer.sv
@@ -48,6 +48,12 @@ module redmule_streamer
 
 localparam int unsigned EW  = `HCI_SIZE_GET_EW(tcdm);
 
+// The load/store cast units sit on the TCDM data bus. With MisalignedAccessSupport
+// the HCI sink/source widen that bus to DataW+32 (the extra word carries the
+// realignment overflow), so the casts must span the full TCDM width or they drop
+// the realignment word (corrupting misaligned, e.g. odd-k_size, transfers).
+localparam int unsigned CastDataW = DataW + (MisalignedAccessSupport ? 32 : 0);
+
 // Non-ECC variant of tcdm size params, used for all internal (non-ECC) interfaces
 localparam hci_size_parameter_t `HCI_SIZE_PARAM(ldst_tcdm) = '{
   DW:  `HCI_SIZE_GET_DW(tcdm),
@@ -236,7 +242,7 @@ assign cast = (ctrl_i.input_cast_src_fmt == fpnew_pkg::FP16) ? 1'b0: 1'b1;
 // This unit uses only the data bus of the TCDM interface. The other buses
 // are assigned manually.
 redmule_castout #(
-  .DataW         ( DataW        ),
+  .DataW         ( CastDataW    ),
   .FpFmtConfig   ( FpFmtConfig  ),
   .IntFmtConfig  ( IntFmtConfig ),
   .SrcFormat     ( FpFormat     )
@@ -386,7 +392,7 @@ for (genvar i = 0; i < NumStreamSources; i++) begin: gen_tcdm2stream
   // This unit uses only the data bus of the TCDM interface. The other buses
   // are assigned manually.
   redmule_castin #(
-    .DataW        ( DataW        ),
+    .DataW        ( CastDataW    ),
     .FpFmtConfig  ( FpFmtConfig  ),
     .IntFmtConfig ( IntFmtConfig ),
     .DstFormat    ( FpFormat     )

--- a/rtl/redmule_streamer.sv
+++ b/rtl/redmule_streamer.sv
@@ -48,10 +48,7 @@ module redmule_streamer
 
 localparam int unsigned EW  = `HCI_SIZE_GET_EW(tcdm);
 
-// The load/store cast units sit on the TCDM data bus. With MisalignedAccessSupport
-// the HCI sink/source widen that bus to DataW+32 (the extra word carries the
-// realignment overflow), so the casts must span the full TCDM width or they drop
-// the realignment word (corrupting misaligned, e.g. odd-k_size, transfers).
+// Cast in/out modules operate on misaligned DataW
 localparam int unsigned CastDataW = DataW + (MisalignedAccessSupport ? 32 : 0);
 
 // Non-ECC variant of tcdm size params, used for all internal (non-ECC) interfaces

--- a/scripts/bwruntests.py
+++ b/scripts/bwruntests.py
@@ -128,7 +128,7 @@ class FinishedProcess(object):
         throughput = 0
         workload = 0
         if returncode == 0:
-            matches = re.findall("# hwpe cycles =\s+(\d+)", stdout)
+            matches = re.findall(r"# hwpe cycles =\s+(\d+)", stdout)
             if matches:
                 exec_time = int(matches[0])
         self.exec_time = exec_time
@@ -174,7 +174,7 @@ def fork(name, cwd, *popenargs, check=False, shell=True,
                     raise
             # measure runtime
             start = time.time()
-            stdout, stderr = process.communicate(input, timeout=args.timeout)
+            stdout, stderr = process.communicate(input, timeout=proc_timeout)
         except TimeoutExpired:
             pgid = os.getpgid(process.pid)
             os.killpg(pgid, signal.SIGKILL)
@@ -183,9 +183,9 @@ def fork(name, cwd, *popenargs, check=False, shell=True,
             # (make -> vsim -> etc). We need to make a process group and kill
             # that
             stdout, stderr = process.communicate()
-            timeoutmsg = 'TIMEOUT after {:f}s'.format(args.timeout)
+            timeoutmsg = 'TIMEOUT after {:f}s'.format(proc_timeout)
 
-            if args.proc_verbose:
+            if proc_verbose:
                 stdout_lock.acquire()
                 print(name)
                 print(timeoutmsg)
@@ -207,7 +207,7 @@ def fork(name, cwd, *popenargs, check=False, shell=True,
         if check and retcode:
             raise CalledProcessError(retcode, process.args,
                                      output=stdout, stderr=stderr)
-        if args.proc_verbose:
+        if proc_verbose:
             stdout_lock.acquire()
             print(name)
             proc_out(cwd, stdout, stderr)
@@ -222,13 +222,17 @@ def fork(name, cwd, *popenargs, check=False, shell=True,
                            stderr.decode('utf-8'),
                            time.time() - start)
 
-def poolInit(s, t, l):
+def poolInit(s, t, l, timeout, verbose):
     global shared_total
     global len_total
     global lock
+    global proc_timeout
+    global proc_verbose
     shared_total = s
     len_total = t
     lock = l
+    proc_timeout = timeout
+    proc_verbose = verbose
 
 if __name__ == '__main__':
     args = runtest.parse_args()
@@ -289,7 +293,7 @@ the pyyaml library which is not installed.""",
     lock = multiprocessing.Lock()
     shared_total = multiprocessing.Value('i', 0)
     len_total = multiprocessing.Value('i', len(tests))
-    pool = multiprocessing.Pool(processes=args.max_procs, initializer=poolInit, initargs=(shared_total, len_total, lock ))
+    pool = multiprocessing.Pool(processes=args.max_procs, initializer=poolInit, initargs=(shared_total, len_total, lock, args.timeout, args.proc_verbose ))
     # Restore SIGINT handler
     signal.signal(signal.SIGINT, original_sigint_handler)
     # Shuffle tests

--- a/scripts/regression-list.sh
+++ b/scripts/regression-list.sh
@@ -28,4 +28,4 @@ N_PROC="${N_PROC:-4}"
 
 export Target
 
-python3 "$ScriptDir/bwruntests.py" --yaml -t $BASE_TIMEOUT -p "$N_PROC" -s "$REGR_FILE"
+python3 "$ScriptDir/bwruntests.py" --yaml -t $BASE_TIMEOUT -p "$N_PROC" "$REGR_FILE"

--- a/scripts/regression-list.sh
+++ b/scripts/regression-list.sh
@@ -28,4 +28,4 @@ N_PROC="${N_PROC:-4}"
 
 export Target
 
-python3 "$ScriptDir/bwruntests.py" --yaml -t $BASE_TIMEOUT -p "$N_PROC" "$REGR_FILE"
+python3 "$ScriptDir/bwruntests.py" --yaml -t $BASE_TIMEOUT -p "$N_PROC" --perf "$ScriptDir/perf.json" "$REGR_FILE"

--- a/scripts/regression-smoke.yml
+++ b/scripts/regression-smoke.yml
@@ -11,4 +11,4 @@
 redmule_regression_smoke:
   M32_N32_K32:
     path: .
-    command: make golden M=32 N=32 K=32 && make sw-clean sw-build M=32 N=32 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=32 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_32_32 | grep -q '\[TB\] - Success!'
+    command: make golden M=32 N=32 K=32 && make sw-clean sw-build M=32 N=32 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=32 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_32_32 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_32_32_32

--- a/scripts/regression.yml
+++ b/scripts/regression.yml
@@ -102,3 +102,147 @@ redmule_regression:
   M12_N30_K15: # odd K misaligned + odd N + M-leftover
     path: .
     command: make golden M=12 N=30 K=15 && make sw-clean sw-build M=12 N=30 K=15 REDMULE_COMPLEX=0 Gcc= && make hw-run M=12 N=30 K=15 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_12_30_15 | grep -q '\[TB\] - Success!'
+  M1_N16_K1:
+    path: .
+    command: make golden M=1 N=16 K=1 && make sw-clean sw-build M=1 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_1 | grep -q '\[TB\] - Success!'
+  M1_N16_K2:
+    path: .
+    command: make golden M=1 N=16 K=2 && make sw-clean sw-build M=1 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_2 | grep -q '\[TB\] - Success!'
+  M1_N16_K4:
+    path: .
+    command: make golden M=1 N=16 K=4 && make sw-clean sw-build M=1 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_4 | grep -q '\[TB\] - Success!'
+  M1_N16_K8:
+    path: .
+    command: make golden M=1 N=16 K=8 && make sw-clean sw-build M=1 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_8 | grep -q '\[TB\] - Success!'
+  M1_N24_K1:
+    path: .
+    command: make golden M=1 N=24 K=1 && make sw-clean sw-build M=1 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_1 | grep -q '\[TB\] - Success!'
+  M1_N24_K2:
+    path: .
+    command: make golden M=1 N=24 K=2 && make sw-clean sw-build M=1 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_2 | grep -q '\[TB\] - Success!'
+  M1_N24_K4:
+    path: .
+    command: make golden M=1 N=24 K=4 && make sw-clean sw-build M=1 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_4 | grep -q '\[TB\] - Success!'
+  M1_N24_K8:
+    path: .
+    command: make golden M=1 N=24 K=8 && make sw-clean sw-build M=1 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_8 | grep -q '\[TB\] - Success!'
+  M1_N32_K1:
+    path: .
+    command: make golden M=1 N=32 K=1 && make sw-clean sw-build M=1 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_1 | grep -q '\[TB\] - Success!'
+  M1_N32_K2:
+    path: .
+    command: make golden M=1 N=32 K=2 && make sw-clean sw-build M=1 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_2 | grep -q '\[TB\] - Success!'
+  M1_N32_K4:
+    path: .
+    command: make golden M=1 N=32 K=4 && make sw-clean sw-build M=1 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_4 | grep -q '\[TB\] - Success!'
+  M1_N32_K8:
+    path: .
+    command: make golden M=1 N=32 K=8 && make sw-clean sw-build M=1 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_8 | grep -q '\[TB\] - Success!'
+  M2_N16_K1:
+    path: .
+    command: make golden M=2 N=16 K=1 && make sw-clean sw-build M=2 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_1 | grep -q '\[TB\] - Success!'
+  M2_N16_K2:
+    path: .
+    command: make golden M=2 N=16 K=2 && make sw-clean sw-build M=2 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_2 | grep -q '\[TB\] - Success!'
+  M2_N16_K4:
+    path: .
+    command: make golden M=2 N=16 K=4 && make sw-clean sw-build M=2 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_4 | grep -q '\[TB\] - Success!'
+  M2_N16_K8:
+    path: .
+    command: make golden M=2 N=16 K=8 && make sw-clean sw-build M=2 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_8 | grep -q '\[TB\] - Success!'
+  M2_N24_K1:
+    path: .
+    command: make golden M=2 N=24 K=1 && make sw-clean sw-build M=2 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_1 | grep -q '\[TB\] - Success!'
+  M2_N24_K2:
+    path: .
+    command: make golden M=2 N=24 K=2 && make sw-clean sw-build M=2 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_2 | grep -q '\[TB\] - Success!'
+  M2_N24_K4:
+    path: .
+    command: make golden M=2 N=24 K=4 && make sw-clean sw-build M=2 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_4 | grep -q '\[TB\] - Success!'
+  M2_N24_K8:
+    path: .
+    command: make golden M=2 N=24 K=8 && make sw-clean sw-build M=2 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_8 | grep -q '\[TB\] - Success!'
+  M2_N32_K1:
+    path: .
+    command: make golden M=2 N=32 K=1 && make sw-clean sw-build M=2 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_1 | grep -q '\[TB\] - Success!'
+  M2_N32_K2:
+    path: .
+    command: make golden M=2 N=32 K=2 && make sw-clean sw-build M=2 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_2 | grep -q '\[TB\] - Success!'
+  M2_N32_K4:
+    path: .
+    command: make golden M=2 N=32 K=4 && make sw-clean sw-build M=2 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_4 | grep -q '\[TB\] - Success!'
+  M2_N32_K8:
+    path: .
+    command: make golden M=2 N=32 K=8 && make sw-clean sw-build M=2 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_8 | grep -q '\[TB\] - Success!'
+  M4_N16_K1:
+    path: .
+    command: make golden M=4 N=16 K=1 && make sw-clean sw-build M=4 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_1 | grep -q '\[TB\] - Success!'
+  M4_N16_K2:
+    path: .
+    command: make golden M=4 N=16 K=2 && make sw-clean sw-build M=4 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_2 | grep -q '\[TB\] - Success!'
+  M4_N16_K4:
+    path: .
+    command: make golden M=4 N=16 K=4 && make sw-clean sw-build M=4 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_4 | grep -q '\[TB\] - Success!'
+  M4_N16_K8:
+    path: .
+    command: make golden M=4 N=16 K=8 && make sw-clean sw-build M=4 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_8 | grep -q '\[TB\] - Success!'
+  M4_N24_K1:
+    path: .
+    command: make golden M=4 N=24 K=1 && make sw-clean sw-build M=4 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_1 | grep -q '\[TB\] - Success!'
+  M4_N24_K2:
+    path: .
+    command: make golden M=4 N=24 K=2 && make sw-clean sw-build M=4 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_2 | grep -q '\[TB\] - Success!'
+  M4_N24_K4:
+    path: .
+    command: make golden M=4 N=24 K=4 && make sw-clean sw-build M=4 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_4 | grep -q '\[TB\] - Success!'
+  M4_N24_K8:
+    path: .
+    command: make golden M=4 N=24 K=8 && make sw-clean sw-build M=4 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_8 | grep -q '\[TB\] - Success!'
+  M4_N32_K1:
+    path: .
+    command: make golden M=4 N=32 K=1 && make sw-clean sw-build M=4 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_1 | grep -q '\[TB\] - Success!'
+  M4_N32_K2:
+    path: .
+    command: make golden M=4 N=32 K=2 && make sw-clean sw-build M=4 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_2 | grep -q '\[TB\] - Success!'
+  M4_N32_K4:
+    path: .
+    command: make golden M=4 N=32 K=4 && make sw-clean sw-build M=4 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_4 | grep -q '\[TB\] - Success!'
+  M4_N32_K8:
+    path: .
+    command: make golden M=4 N=32 K=8 && make sw-clean sw-build M=4 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_8 | grep -q '\[TB\] - Success!'
+  M8_N16_K1:
+    path: .
+    command: make golden M=8 N=16 K=1 && make sw-clean sw-build M=8 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_1 | grep -q '\[TB\] - Success!'
+  M8_N16_K2:
+    path: .
+    command: make golden M=8 N=16 K=2 && make sw-clean sw-build M=8 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_2 | grep -q '\[TB\] - Success!'
+  M8_N16_K4:
+    path: .
+    command: make golden M=8 N=16 K=4 && make sw-clean sw-build M=8 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_4 | grep -q '\[TB\] - Success!'
+  M8_N16_K8:
+    path: .
+    command: make golden M=8 N=16 K=8 && make sw-clean sw-build M=8 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_8 | grep -q '\[TB\] - Success!'
+  M8_N24_K1:
+    path: .
+    command: make golden M=8 N=24 K=1 && make sw-clean sw-build M=8 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_1 | grep -q '\[TB\] - Success!'
+  M8_N24_K2:
+    path: .
+    command: make golden M=8 N=24 K=2 && make sw-clean sw-build M=8 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_2 | grep -q '\[TB\] - Success!'
+  M8_N24_K4:
+    path: .
+    command: make golden M=8 N=24 K=4 && make sw-clean sw-build M=8 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_4 | grep -q '\[TB\] - Success!'
+  M8_N24_K8:
+    path: .
+    command: make golden M=8 N=24 K=8 && make sw-clean sw-build M=8 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_8 | grep -q '\[TB\] - Success!'
+  M8_N32_K1:
+    path: .
+    command: make golden M=8 N=32 K=1 && make sw-clean sw-build M=8 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_1 | grep -q '\[TB\] - Success!'
+  M8_N32_K2:
+    path: .
+    command: make golden M=8 N=32 K=2 && make sw-clean sw-build M=8 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_2 | grep -q '\[TB\] - Success!'
+  M8_N32_K4:
+    path: .
+    command: make golden M=8 N=32 K=4 && make sw-clean sw-build M=8 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_4 | grep -q '\[TB\] - Success!'
+  M8_N32_K8:
+    path: .
+    command: make golden M=8 N=32 K=8 && make sw-clean sw-build M=8 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_8 | grep -q '\[TB\] - Success!'

--- a/scripts/regression.yml
+++ b/scripts/regression.yml
@@ -63,3 +63,42 @@ redmule_regression:
   M16_N32_K18: # small trailing K-leftover (16+2) + N-tiling (bias-push-height race)
     path: .
     command: make golden M=16 N=32 K=18 && make sw-clean sw-build M=16 N=32 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=32 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_32_18 | grep -q '\[TB\] - Success!'
+  M24_N16_K18: # even K-leftover (16+2), 4-aligned Z stride, no N-tiling
+    path: .
+    command: make golden M=24 N=16 K=18 && make sw-clean sw-build M=24 N=16 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=16 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_16_18 | grep -q '\[TB\] - Success!'
+  M8_N16_K17: # odd K -> misaligned (2B) Z stride, single M-block (misaligned cold-start repro)
+    path: .
+    command: make golden M=8 N=16 K=17 && make sw-clean sw-build M=8 N=16 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_17 | grep -q '\[TB\] - Success!'
+  M16_N16_K13: # odd K sub-tile leftover (13 < 16), misaligned
+    path: .
+    command: make golden M=16 N=16 K=13 && make sw-clean sw-build M=16 N=16 K=13 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=13 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_13 | grep -q '\[TB\] - Success!'
+  M16_N16_K15: # odd K sub-tile leftover (15 < 16), misaligned
+    path: .
+    command: make golden M=16 N=16 K=15 && make sw-clean sw-build M=16 N=16 K=15 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=15 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_15 | grep -q '\[TB\] - Success!'
+  M16_N16_K17: # odd K (16+1) misaligned, multi-M-block
+    path: .
+    command: make golden M=16 N=16 K=17 && make sw-clean sw-build M=16 N=16 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_17 | grep -q '\[TB\] - Success!'
+  M24_N16_K17: # odd K misaligned, first-M-block cold-start check (multi-block)
+    path: .
+    command: make golden M=24 N=16 K=17 && make sw-clean sw-build M=24 N=16 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=16 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_16_17 | grep -q '\[TB\] - Success!'
+  M32_N32_K17: # odd K misaligned + N-tiling + multiple M/K tiles
+    path: .
+    command: make golden M=32 N=32 K=17 && make sw-clean sw-build M=32 N=32 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=32 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_32_17 | grep -q '\[TB\] - Success!'
+  M24_N32_K17: # odd K misaligned + N-tiling + M multi-block
+    path: .
+    command: make golden M=24 N=32 K=17 && make sw-clean sw-build M=24 N=32 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=32 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_32_17 | grep -q '\[TB\] - Success!'
+  M30_N32_K17: # odd K misaligned + N-tiling + M-leftover
+    path: .
+    command: make golden M=30 N=32 K=17 && make sw-clean sw-build M=30 N=32 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=30 N=32 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_30_32_17 | grep -q '\[TB\] - Success!'
+  M16_N32_K33: # odd K > 32 (two full K-tiles + odd leftover) misaligned + N-tiling
+    path: .
+    command: make golden M=16 N=32 K=33 && make sw-clean sw-build M=16 N=32 K=33 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=32 K=33 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_32_33 | grep -q '\[TB\] - Success!'
+  M32_N48_K25: # odd K misaligned + N-tiling, larger
+    path: .
+    command: make golden M=32 N=48 K=25 && make sw-clean sw-build M=32 N=48 K=25 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=48 K=25 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_48_25 | grep -q '\[TB\] - Success!'
+  M48_N32_K19: # odd K misaligned, larger M (many M-blocks)
+    path: .
+    command: make golden M=48 N=32 K=19 && make sw-clean sw-build M=48 N=32 K=19 REDMULE_COMPLEX=0 Gcc= && make hw-run M=48 N=32 K=19 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_48_32_19 | grep -q '\[TB\] - Success!'
+  M12_N30_K15: # odd K misaligned + odd N + M-leftover
+    path: .
+    command: make golden M=12 N=30 K=15 && make sw-clean sw-build M=12 N=30 K=15 REDMULE_COMPLEX=0 Gcc= && make hw-run M=12 N=30 K=15 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_12_30_15 | grep -q '\[TB\] - Success!'

--- a/scripts/regression.yml
+++ b/scripts/regression.yml
@@ -14,235 +14,235 @@
 redmule_regression:
   M96_N96_K96:
     path: .
-    command: make golden M=96 N=96 K=96 && make sw-clean sw-build M=96 N=96 K=96 REDMULE_COMPLEX=0 Gcc= && make hw-run M=96 N=96 K=96 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_96_96_96 | grep -q '\[TB\] - Success!'
+    command: make golden M=96 N=96 K=96 && make sw-clean sw-build M=96 N=96 K=96 REDMULE_COMPLEX=0 Gcc= && make hw-run M=96 N=96 K=96 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_96_96_96 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_96_96_96
   M128_N128_K128:
     path: .
-    command: make golden M=128 N=128 K=128 && make sw-clean sw-build M=128 N=128 K=128 REDMULE_COMPLEX=0 Gcc= && make hw-run M=128 N=128 K=128 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_128_128_128 | grep -q '\[TB\] - Success!'
+    command: make golden M=128 N=128 K=128 && make sw-clean sw-build M=128 N=128 K=128 REDMULE_COMPLEX=0 Gcc= && make hw-run M=128 N=128 K=128 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_128_128_128 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_128_128_128
   M48_N48_K48:
     path: .
-    command: make golden M=48 N=48 K=48 && make sw-clean sw-build M=48 N=48 K=48 REDMULE_COMPLEX=0 Gcc= && make hw-run M=48 N=48 K=48 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_48_48_48 | grep -q '\[TB\] - Success!'
+    command: make golden M=48 N=48 K=48 && make sw-clean sw-build M=48 N=48 K=48 REDMULE_COMPLEX=0 Gcc= && make hw-run M=48 N=48 K=48 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_48_48_48 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_48_48_48
   M12_N16_K16:
     path: .
-    command: make golden M=12 N=16 K=16 && make sw-clean sw-build M=12 N=16 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=12 N=16 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_12_16_16 | grep -q '\[TB\] - Success!'
+    command: make golden M=12 N=16 K=16 && make sw-clean sw-build M=12 N=16 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=12 N=16 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_12_16_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_12_16_16
   M24_N16_K16:
     path: .
-    command: make golden M=24 N=16 K=16 && make sw-clean sw-build M=24 N=16 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=16 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_16_16 | grep -q '\[TB\] - Success!'
+    command: make golden M=24 N=16 K=16 && make sw-clean sw-build M=24 N=16 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=16 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_16_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_24_16_16
   M48_N32_K32:
     path: .
-    command: make golden M=48 N=32 K=32 && make sw-clean sw-build M=48 N=32 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=48 N=32 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_48_32_32 | grep -q '\[TB\] - Success!'
+    command: make golden M=48 N=32 K=32 && make sw-clean sw-build M=48 N=32 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=48 N=32 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_48_32_32 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_48_32_32
   M30_N32_K18: # small trailing K-leftover (16+2) + N-tiling + M-leftover
     path: .
-    command: make golden M=30 N=32 K=18 && make sw-clean sw-build M=30 N=32 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=30 N=32 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_30_32_18 | grep -q '\[TB\] - Success!'
+    command: make golden M=30 N=32 K=18 && make sw-clean sw-build M=30 N=32 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=30 N=32 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_30_32_18 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_30_32_18
   M24_N32_K2:
     path: .
-    command: make golden M=24 N=32 K=2 && make sw-clean sw-build M=24 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_32_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=24 N=32 K=2 && make sw-clean sw-build M=24 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_32_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_24_32_2
   M18_N32_K16:
     path: .
-    command: make golden M=18 N=32 K=16 && make sw-clean sw-build M=18 N=32 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=18 N=32 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_18_32_16 | grep -q '\[TB\] - Success!'
+    command: make golden M=18 N=32 K=16 && make sw-clean sw-build M=18 N=32 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=18 N=32 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_18_32_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_18_32_16
   M6_N32_K4:
     path: .
-    command: make golden M=6 N=32 K=4 && make sw-clean sw-build M=6 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=6 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_6_32_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=6 N=32 K=4 && make sw-clean sw-build M=6 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=6 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_6_32_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_6_32_4
   M36_N32_K32:
     path: .
-    command: make golden M=36 N=32 K=32 && make sw-clean sw-build M=36 N=32 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=36 N=32 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_36_32_32 | grep -q '\[TB\] - Success!'
+    command: make golden M=36 N=32 K=32 && make sw-clean sw-build M=36 N=32 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=36 N=32 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_36_32_32 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_36_32_32
   M12_N30_K16:
     path: .
-    command: make golden M=12 N=30 K=16 && make sw-clean sw-build M=12 N=30 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=12 N=30 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_12_30_16 | grep -q '\[TB\] - Success!'
+    command: make golden M=12 N=30 K=16 && make sw-clean sw-build M=12 N=30 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=12 N=30 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_12_30_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_12_30_16
   M24_N18_K32:
     path: .
-    command: make golden M=24 N=18 K=32 && make sw-clean sw-build M=24 N=18 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=18 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_18_32 | grep -q '\[TB\] - Success!'
+    command: make golden M=24 N=18 K=32 && make sw-clean sw-build M=24 N=18 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=18 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_18_32 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_24_18_32
   M24_N20_K32:
     path: .
-    command: make golden M=24 N=20 K=32 && make sw-clean sw-build M=24 N=20 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=20 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_20_32 | grep -q '\[TB\] - Success!'
+    command: make golden M=24 N=20 K=32 && make sw-clean sw-build M=24 N=20 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=20 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_20_32 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_24_20_32
   M16_N16_K24: # K-leftover: last store tile is a leftover (8 of 16 cols)
     path: .
-    command: make golden M=16 N=16 K=24 && make sw-clean sw-build M=16 N=16 K=24 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=24 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_24 | grep -q '\[TB\] - Success!'
+    command: make golden M=16 N=16 K=24 && make sw-clean sw-build M=16 N=16 K=24 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=24 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_24 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_16_24
   M32_N32_K24: # K-leftover across multiple K and row tiles
     path: .
-    command: make golden M=32 N=32 K=24 && make sw-clean sw-build M=32 N=32 K=24 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=32 K=24 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_32_24 | grep -q '\[TB\] - Success!'
+    command: make golden M=32 N=32 K=24 && make sw-clean sw-build M=32 N=32 K=24 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=32 K=24 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_32_24 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_32_32_24
   M16_N32_K18: # small trailing K-leftover (16+2) + N-tiling (bias-push-height race)
     path: .
-    command: make golden M=16 N=32 K=18 && make sw-clean sw-build M=16 N=32 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=32 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_32_18 | grep -q '\[TB\] - Success!'
+    command: make golden M=16 N=32 K=18 && make sw-clean sw-build M=16 N=32 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=32 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_32_18 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_32_18
   M24_N16_K18: # even K-leftover (16+2), 4-aligned Z stride, no N-tiling
     path: .
-    command: make golden M=24 N=16 K=18 && make sw-clean sw-build M=24 N=16 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=16 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_16_18 | grep -q '\[TB\] - Success!'
+    command: make golden M=24 N=16 K=18 && make sw-clean sw-build M=24 N=16 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=16 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_16_18 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_24_16_18
   M8_N16_K17: # odd K -> misaligned (2B) Z stride, single M-block (misaligned cold-start repro)
     path: .
-    command: make golden M=8 N=16 K=17 && make sw-clean sw-build M=8 N=16 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_17 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=16 K=17 && make sw-clean sw-build M=8 N=16 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_17 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_16_17
   M16_N16_K13: # odd K sub-tile leftover (13 < 16), misaligned
     path: .
-    command: make golden M=16 N=16 K=13 && make sw-clean sw-build M=16 N=16 K=13 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=13 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_13 | grep -q '\[TB\] - Success!'
+    command: make golden M=16 N=16 K=13 && make sw-clean sw-build M=16 N=16 K=13 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=13 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_13 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_16_13
   M16_N16_K15: # odd K sub-tile leftover (15 < 16), misaligned
     path: .
-    command: make golden M=16 N=16 K=15 && make sw-clean sw-build M=16 N=16 K=15 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=15 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_15 | grep -q '\[TB\] - Success!'
+    command: make golden M=16 N=16 K=15 && make sw-clean sw-build M=16 N=16 K=15 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=15 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_15 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_16_15
   M16_N16_K17: # odd K (16+1) misaligned, multi-M-block
     path: .
-    command: make golden M=16 N=16 K=17 && make sw-clean sw-build M=16 N=16 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_17 | grep -q '\[TB\] - Success!'
+    command: make golden M=16 N=16 K=17 && make sw-clean sw-build M=16 N=16 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_17 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_16_17
   M24_N16_K17: # odd K misaligned, first-M-block cold-start check (multi-block)
     path: .
-    command: make golden M=24 N=16 K=17 && make sw-clean sw-build M=24 N=16 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=16 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_16_17 | grep -q '\[TB\] - Success!'
+    command: make golden M=24 N=16 K=17 && make sw-clean sw-build M=24 N=16 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=16 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_16_17 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_24_16_17
   M32_N32_K17: # odd K misaligned + N-tiling + multiple M/K tiles
     path: .
-    command: make golden M=32 N=32 K=17 && make sw-clean sw-build M=32 N=32 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=32 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_32_17 | grep -q '\[TB\] - Success!'
+    command: make golden M=32 N=32 K=17 && make sw-clean sw-build M=32 N=32 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=32 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_32_17 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_32_32_17
   M24_N32_K17: # odd K misaligned + N-tiling + M multi-block
     path: .
-    command: make golden M=24 N=32 K=17 && make sw-clean sw-build M=24 N=32 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=32 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_32_17 | grep -q '\[TB\] - Success!'
+    command: make golden M=24 N=32 K=17 && make sw-clean sw-build M=24 N=32 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=32 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_32_17 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_24_32_17
   M30_N32_K17: # odd K misaligned + N-tiling + M-leftover
     path: .
-    command: make golden M=30 N=32 K=17 && make sw-clean sw-build M=30 N=32 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=30 N=32 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_30_32_17 | grep -q '\[TB\] - Success!'
+    command: make golden M=30 N=32 K=17 && make sw-clean sw-build M=30 N=32 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=30 N=32 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_30_32_17 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_30_32_17
   M16_N32_K33: # odd K > 32 (two full K-tiles + odd leftover) misaligned + N-tiling
     path: .
-    command: make golden M=16 N=32 K=33 && make sw-clean sw-build M=16 N=32 K=33 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=32 K=33 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_32_33 | grep -q '\[TB\] - Success!'
+    command: make golden M=16 N=32 K=33 && make sw-clean sw-build M=16 N=32 K=33 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=32 K=33 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_32_33 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_32_33
   M32_N48_K25: # odd K misaligned + N-tiling, larger
     path: .
-    command: make golden M=32 N=48 K=25 && make sw-clean sw-build M=32 N=48 K=25 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=48 K=25 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_48_25 | grep -q '\[TB\] - Success!'
+    command: make golden M=32 N=48 K=25 && make sw-clean sw-build M=32 N=48 K=25 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=48 K=25 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_48_25 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_32_48_25
   M48_N32_K19: # odd K misaligned, larger M (many M-blocks)
     path: .
-    command: make golden M=48 N=32 K=19 && make sw-clean sw-build M=48 N=32 K=19 REDMULE_COMPLEX=0 Gcc= && make hw-run M=48 N=32 K=19 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_48_32_19 | grep -q '\[TB\] - Success!'
+    command: make golden M=48 N=32 K=19 && make sw-clean sw-build M=48 N=32 K=19 REDMULE_COMPLEX=0 Gcc= && make hw-run M=48 N=32 K=19 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_48_32_19 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_48_32_19
   M12_N30_K15: # odd K misaligned + odd N + M-leftover
     path: .
-    command: make golden M=12 N=30 K=15 && make sw-clean sw-build M=12 N=30 K=15 REDMULE_COMPLEX=0 Gcc= && make hw-run M=12 N=30 K=15 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_12_30_15 | grep -q '\[TB\] - Success!'
+    command: make golden M=12 N=30 K=15 && make sw-clean sw-build M=12 N=30 K=15 REDMULE_COMPLEX=0 Gcc= && make hw-run M=12 N=30 K=15 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_12_30_15 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_12_30_15
   M1_N16_K1:
     path: .
-    command: make golden M=1 N=16 K=1 && make sw-clean sw-build M=1 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=16 K=1 && make sw-clean sw-build M=1 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_16_1
   M1_N16_K2:
     path: .
-    command: make golden M=1 N=16 K=2 && make sw-clean sw-build M=1 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=16 K=2 && make sw-clean sw-build M=1 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_16_2
   M1_N16_K4:
     path: .
-    command: make golden M=1 N=16 K=4 && make sw-clean sw-build M=1 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=16 K=4 && make sw-clean sw-build M=1 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_16_4
   M1_N16_K8:
     path: .
-    command: make golden M=1 N=16 K=8 && make sw-clean sw-build M=1 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=16 K=8 && make sw-clean sw-build M=1 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_16_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_16_8
   M1_N24_K1:
     path: .
-    command: make golden M=1 N=24 K=1 && make sw-clean sw-build M=1 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=24 K=1 && make sw-clean sw-build M=1 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_24_1
   M1_N24_K2:
     path: .
-    command: make golden M=1 N=24 K=2 && make sw-clean sw-build M=1 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=24 K=2 && make sw-clean sw-build M=1 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_24_2
   M1_N24_K4:
     path: .
-    command: make golden M=1 N=24 K=4 && make sw-clean sw-build M=1 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=24 K=4 && make sw-clean sw-build M=1 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_24_4
   M1_N24_K8:
     path: .
-    command: make golden M=1 N=24 K=8 && make sw-clean sw-build M=1 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=24 K=8 && make sw-clean sw-build M=1 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_24_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_24_8
   M1_N32_K1:
     path: .
-    command: make golden M=1 N=32 K=1 && make sw-clean sw-build M=1 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=32 K=1 && make sw-clean sw-build M=1 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_32_1
   M1_N32_K2:
     path: .
-    command: make golden M=1 N=32 K=2 && make sw-clean sw-build M=1 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=32 K=2 && make sw-clean sw-build M=1 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_32_2
   M1_N32_K4:
     path: .
-    command: make golden M=1 N=32 K=4 && make sw-clean sw-build M=1 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=32 K=4 && make sw-clean sw-build M=1 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_32_4
   M1_N32_K8:
     path: .
-    command: make golden M=1 N=32 K=8 && make sw-clean sw-build M=1 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=1 N=32 K=8 && make sw-clean sw-build M=1 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_32_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_32_8
   M2_N16_K1:
     path: .
-    command: make golden M=2 N=16 K=1 && make sw-clean sw-build M=2 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=16 K=1 && make sw-clean sw-build M=2 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_16_1
   M2_N16_K2:
     path: .
-    command: make golden M=2 N=16 K=2 && make sw-clean sw-build M=2 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=16 K=2 && make sw-clean sw-build M=2 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_16_2
   M2_N16_K4:
     path: .
-    command: make golden M=2 N=16 K=4 && make sw-clean sw-build M=2 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=16 K=4 && make sw-clean sw-build M=2 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_16_4
   M2_N16_K8:
     path: .
-    command: make golden M=2 N=16 K=8 && make sw-clean sw-build M=2 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=16 K=8 && make sw-clean sw-build M=2 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_16_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_16_8
   M2_N24_K1:
     path: .
-    command: make golden M=2 N=24 K=1 && make sw-clean sw-build M=2 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=24 K=1 && make sw-clean sw-build M=2 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_24_1
   M2_N24_K2:
     path: .
-    command: make golden M=2 N=24 K=2 && make sw-clean sw-build M=2 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=24 K=2 && make sw-clean sw-build M=2 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_24_2
   M2_N24_K4:
     path: .
-    command: make golden M=2 N=24 K=4 && make sw-clean sw-build M=2 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=24 K=4 && make sw-clean sw-build M=2 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_24_4
   M2_N24_K8:
     path: .
-    command: make golden M=2 N=24 K=8 && make sw-clean sw-build M=2 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=24 K=8 && make sw-clean sw-build M=2 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_24_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_24_8
   M2_N32_K1:
     path: .
-    command: make golden M=2 N=32 K=1 && make sw-clean sw-build M=2 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=32 K=1 && make sw-clean sw-build M=2 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_32_1
   M2_N32_K2:
     path: .
-    command: make golden M=2 N=32 K=2 && make sw-clean sw-build M=2 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=32 K=2 && make sw-clean sw-build M=2 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_32_2
   M2_N32_K4:
     path: .
-    command: make golden M=2 N=32 K=4 && make sw-clean sw-build M=2 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=32 K=4 && make sw-clean sw-build M=2 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_32_4
   M2_N32_K8:
     path: .
-    command: make golden M=2 N=32 K=8 && make sw-clean sw-build M=2 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=2 N=32 K=8 && make sw-clean sw-build M=2 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=2 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_2_32_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_2_32_8
   M4_N16_K1:
     path: .
-    command: make golden M=4 N=16 K=1 && make sw-clean sw-build M=4 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=16 K=1 && make sw-clean sw-build M=4 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_16_1
   M4_N16_K2:
     path: .
-    command: make golden M=4 N=16 K=2 && make sw-clean sw-build M=4 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=16 K=2 && make sw-clean sw-build M=4 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_16_2
   M4_N16_K4:
     path: .
-    command: make golden M=4 N=16 K=4 && make sw-clean sw-build M=4 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=16 K=4 && make sw-clean sw-build M=4 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_16_4
   M4_N16_K8:
     path: .
-    command: make golden M=4 N=16 K=8 && make sw-clean sw-build M=4 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=16 K=8 && make sw-clean sw-build M=4 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_16_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_16_8
   M4_N24_K1:
     path: .
-    command: make golden M=4 N=24 K=1 && make sw-clean sw-build M=4 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=24 K=1 && make sw-clean sw-build M=4 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_24_1
   M4_N24_K2:
     path: .
-    command: make golden M=4 N=24 K=2 && make sw-clean sw-build M=4 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=24 K=2 && make sw-clean sw-build M=4 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_24_2
   M4_N24_K4:
     path: .
-    command: make golden M=4 N=24 K=4 && make sw-clean sw-build M=4 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=24 K=4 && make sw-clean sw-build M=4 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_24_4
   M4_N24_K8:
     path: .
-    command: make golden M=4 N=24 K=8 && make sw-clean sw-build M=4 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=24 K=8 && make sw-clean sw-build M=4 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_24_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_24_8
   M4_N32_K1:
     path: .
-    command: make golden M=4 N=32 K=1 && make sw-clean sw-build M=4 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=32 K=1 && make sw-clean sw-build M=4 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_32_1
   M4_N32_K2:
     path: .
-    command: make golden M=4 N=32 K=2 && make sw-clean sw-build M=4 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=32 K=2 && make sw-clean sw-build M=4 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_32_2
   M4_N32_K4:
     path: .
-    command: make golden M=4 N=32 K=4 && make sw-clean sw-build M=4 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=32 K=4 && make sw-clean sw-build M=4 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_32_4
   M4_N32_K8:
     path: .
-    command: make golden M=4 N=32 K=8 && make sw-clean sw-build M=4 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=4 N=32 K=8 && make sw-clean sw-build M=4 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=4 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_4_32_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_4_32_8
   M8_N16_K1:
     path: .
-    command: make golden M=8 N=16 K=1 && make sw-clean sw-build M=8 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=16 K=1 && make sw-clean sw-build M=8 N=16 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_16_1
   M8_N16_K2:
     path: .
-    command: make golden M=8 N=16 K=2 && make sw-clean sw-build M=8 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=16 K=2 && make sw-clean sw-build M=8 N=16 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_16_2
   M8_N16_K4:
     path: .
-    command: make golden M=8 N=16 K=4 && make sw-clean sw-build M=8 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=16 K=4 && make sw-clean sw-build M=8 N=16 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_16_4
   M8_N16_K8:
     path: .
-    command: make golden M=8 N=16 K=8 && make sw-clean sw-build M=8 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=16 K=8 && make sw-clean sw-build M=8 N=16 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=16 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_16_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_16_8
   M8_N24_K1:
     path: .
-    command: make golden M=8 N=24 K=1 && make sw-clean sw-build M=8 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=24 K=1 && make sw-clean sw-build M=8 N=24 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_24_1
   M8_N24_K2:
     path: .
-    command: make golden M=8 N=24 K=2 && make sw-clean sw-build M=8 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=24 K=2 && make sw-clean sw-build M=8 N=24 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_24_2
   M8_N24_K4:
     path: .
-    command: make golden M=8 N=24 K=4 && make sw-clean sw-build M=8 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=24 K=4 && make sw-clean sw-build M=8 N=24 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_24_4
   M8_N24_K8:
     path: .
-    command: make golden M=8 N=24 K=8 && make sw-clean sw-build M=8 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=24 K=8 && make sw-clean sw-build M=8 N=24 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=24 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_24_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_24_8
   M8_N32_K1:
     path: .
-    command: make golden M=8 N=32 K=1 && make sw-clean sw-build M=8 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_1 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=32 K=1 && make sw-clean sw-build M=8 N=32 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_32_1
   M8_N32_K2:
     path: .
-    command: make golden M=8 N=32 K=2 && make sw-clean sw-build M=8 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_2 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=32 K=2 && make sw-clean sw-build M=8 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_2 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_32_2
   M8_N32_K4:
     path: .
-    command: make golden M=8 N=32 K=4 && make sw-clean sw-build M=8 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_4 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=32 K=4 && make sw-clean sw-build M=8 N=32 K=4 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=4 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_4 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_32_4
   M8_N32_K8:
     path: .
-    command: make golden M=8 N=32 K=8 && make sw-clean sw-build M=8 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_8 | grep -q '\[TB\] - Success!'
+    command: make golden M=8 N=32 K=8 && make sw-clean sw-build M=8 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_32_8

--- a/scripts/regression.yml
+++ b/scripts/regression.yml
@@ -30,11 +30,9 @@ redmule_regression:
   M48_N32_K32:
     path: .
     command: make golden M=48 N=32 K=32 && make sw-clean sw-build M=48 N=32 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=48 N=32 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_48_32_32 | grep -q '\[TB\] - Success!'
-  # M30_N32_K18: # STILL BROKEN (separate bug): a *small* trailing K-leftover
-  #   path: .     # (K=18 -> 16+2) combined with N-tiling (N=32) hits a z-buffer
-  #               # store/push race (see redmule_z_buffer.sv "very small leftovers
-  #               # on K"), independent of the z_config_fast store-geometry fix.
-  #   command: make golden M=30 N=32 K=18 && make sw-clean sw-build M=30 N=32 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=30 N=32 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_30_32_18 | grep -q '\[TB\] - Success!'
+  M30_N32_K18: # small trailing K-leftover (16+2) + N-tiling + M-leftover
+    path: .
+    command: make golden M=30 N=32 K=18 && make sw-clean sw-build M=30 N=32 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=30 N=32 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_30_32_18 | grep -q '\[TB\] - Success!'
   M24_N32_K2:
     path: .
     command: make golden M=24 N=32 K=2 && make sw-clean sw-build M=24 N=32 K=2 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=32 K=2 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_32_2 | grep -q '\[TB\] - Success!'
@@ -62,3 +60,6 @@ redmule_regression:
   M32_N32_K24: # K-leftover across multiple K and row tiles
     path: .
     command: make golden M=32 N=32 K=24 && make sw-clean sw-build M=32 N=32 K=24 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=32 K=24 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_32_24 | grep -q '\[TB\] - Success!'
+  M16_N32_K18: # small trailing K-leftover (16+2) + N-tiling (bias-push-height race)
+    path: .
+    command: make golden M=16 N=32 K=18 && make sw-clean sw-build M=16 N=32 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=32 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_32_18 | grep -q '\[TB\] - Success!'

--- a/scripts/regression.yml
+++ b/scripts/regression.yml
@@ -30,8 +30,10 @@ redmule_regression:
   M48_N32_K32:
     path: .
     command: make golden M=48 N=32 K=32 && make sw-clean sw-build M=48 N=32 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=48 N=32 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_48_32_32 | grep -q '\[TB\] - Success!'
-  # M30_N32_K18: # currently broken!! FIXME
-  #   path: .
+  # M30_N32_K18: # STILL BROKEN (separate bug): a *small* trailing K-leftover
+  #   path: .     # (K=18 -> 16+2) combined with N-tiling (N=32) hits a z-buffer
+  #               # store/push race (see redmule_z_buffer.sv "very small leftovers
+  #               # on K"), independent of the z_config_fast store-geometry fix.
   #   command: make golden M=30 N=32 K=18 && make sw-clean sw-build M=30 N=32 K=18 REDMULE_COMPLEX=0 Gcc= && make hw-run M=30 N=32 K=18 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_30_32_18 | grep -q '\[TB\] - Success!'
   M24_N32_K2:
     path: .
@@ -54,3 +56,9 @@ redmule_regression:
   M24_N20_K32:
     path: .
     command: make golden M=24 N=20 K=32 && make sw-clean sw-build M=24 N=20 K=32 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=20 K=32 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_20_32 | grep -q '\[TB\] - Success!'
+  M16_N16_K24: # K-leftover: last store tile is a leftover (8 of 16 cols)
+    path: .
+    command: make golden M=16 N=16 K=24 && make sw-clean sw-build M=16 N=16 K=24 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=16 K=24 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_16_24 | grep -q '\[TB\] - Success!'
+  M32_N32_K24: # K-leftover across multiple K and row tiles
+    path: .
+    command: make golden M=32 N=32 K=24 && make sw-clean sw-build M=32 N=32 K=24 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=32 K=24 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_32_24 | grep -q '\[TB\] - Success!'

--- a/target/sim/src/redmule_tb.sv
+++ b/target/sim/src/redmule_tb.sv
@@ -30,7 +30,10 @@ module redmule_tb
   // parameters
   localparam int unsigned NC = 1;
   localparam int unsigned ID = 4; // matches the OpIdWidth used inside redmule_top's target decoder
-  localparam int unsigned DW = redmule_pkg::MaxDataW;
+  // RedMulE TCDM data width. With MisalignedAccessSupport=1 the streamer expects
+  // the TCDM interface to be DataW+32 (extra word for realignment), see
+  // redmule_streamer.sv tcdm_size_check_dw. DataW here is 256 (see i_redmule_wrap).
+  localparam int unsigned DW = 256 + 32;
   localparam int unsigned MP = DW/32;
   // HCI size parameter for RedMulE's TCDM port. It must be forwarded to
   // redmule_mm_wrap (redmule_top forwards it verbatim to the streamer, with no
@@ -164,11 +167,12 @@ module redmule_tb
                        other_r_valid    ;
 
   redmule_mm_wrap #(
-    .HCI_SIZE_tcdm ( HciSizeTcdm ),
-    .DataW         ( 256 ),
-    .Height        ( 8   ),
-    .Width         ( 8   ),
-    .NumPipeRegs   ( 1   )
+    .HCI_SIZE_tcdm           ( HciSizeTcdm ),
+    .DataW                   ( 256         ),
+    .MisalignedAccessSupport ( 1           ),
+    .Height                  ( 8           ),
+    .Width                   ( 8           ),
+    .NumPipeRegs             ( 1           )
   ) i_redmule_wrap (
     .clk_i       ( clk_i        ),
     .rst_ni      ( rst_ni       ),

--- a/target/sim/src/redmule_tb.sv
+++ b/target/sim/src/redmule_tb.sv
@@ -299,6 +299,15 @@ module redmule_tb
   integer f_x, f_W, f_y, f_tau;
   logic start;
   int cnt_rd, cnt_wr;
+  int unsigned cnt_cycles;
+
+  always_ff @(posedge clk_i or negedge rst_ni)
+  begin
+    if(~rst_ni)
+      cnt_cycles <= 0;
+    else if(redmule_busy)
+      cnt_cycles <= cnt_cycles + 1;
+  end
 
   int errors = -1;
   always_ff @(posedge clk_i)
@@ -333,6 +342,7 @@ module redmule_tb
     end
     $display("[TB] - cnt_rd=%-8d", cnt_rd);
     $display("[TB] - cnt_wr=%-8d", cnt_wr);
+    $display("# hwpe cycles = %0d", cnt_cycles);
     if(errors != 0) begin
       $display("[TB] - Fail!");
       $error("[TB] - errors=%08x", errors);

--- a/target/sim/src/redmule_tb.sv
+++ b/target/sim/src/redmule_tb.sv
@@ -30,10 +30,7 @@ module redmule_tb
   // parameters
   localparam int unsigned NC = 1;
   localparam int unsigned ID = 4; // matches the OpIdWidth used inside redmule_top's target decoder
-  // RedMulE TCDM data width. With MisalignedAccessSupport=1 the streamer expects
-  // the TCDM interface to be DataW+32 (extra word for realignment), see
-  // redmule_streamer.sv tcdm_size_check_dw. DataW here is 256 (see i_redmule_wrap).
-  localparam int unsigned DW = 256 + 32;
+  localparam int unsigned DW = 256 + 32; // TCDM data width including MisalignedAccessSupport=1
   localparam int unsigned MP = DW/32;
   // HCI size parameter for RedMulE's TCDM port. It must be forwarded to
   // redmule_mm_wrap (redmule_top forwards it verbatim to the streamer, with no

--- a/target/sim/verilator/verilator.mk
+++ b/target/sim/verilator/verilator.mk
@@ -50,8 +50,8 @@ hw-run:
 	+STIM_INSTR=$(STIM_INSTR)           \
 	+STIM_DATA=$(STIM_DATA)             \
 	$(if $(filter 1,$(gui)),,+NOTRACE)
-ifeq ($(gui),1)
-	$(GtkWave) $(VerilatorWaves)
-endif
+#ifeq ($(gui),1)
+#	$(GtkWave) $(VerilatorWaves)
+#endif
 
 hw-all: hw-clean hw-script hw-build hw-run


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on enhanced benchmarking and reporting, scheduler correctness, and improved support for misaligned data access. The most significant changes are the integration of automated performance benchmarks into CI, a major scheduler fix to correctly handle store-side tiling, and updates to the test infrastructure to support these features.
Support for leftover sizes in `M`, `K`, and (partially - see the _Limitations_ bullet point) is greatly improved. Many regression tests are added to the Verilator-based CI.

**Limitations**
- Currently, there is no support for `N<=8`. This is a known issue that will be target of a future update.
- The testbench only verifies the `Height=Width=8`, `NumPipeRegs=1`, `DataW=256` case so far. 

**Benchmarking and CI integration:**

* Added a CI workflow step that stores and publishes HWPE job duration benchmarks as historical trend charts on pushes to the `devel` branch, using `github-action-benchmark` and updating the documentation to reference these charts. (`.github/workflows/ci.yml`, `README.md`) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR63-R72) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R101-R103)
* Modified `scripts/regression-list.sh` and `scripts/bwruntests.py` to generate and pass benchmark results in `perf.json` for CI reporting. (`scripts/regression-list.sh`, `scripts/bwruntests.py`) [[1]](diffhunk://#diff-a7e91b96ea0a23fe8c5c8463bef8ff4c1aa67a808e535d1099b8bd49fb929d02L31-R31) [[2]](diffhunk://#diff-be46282273957a0b06bf2807906a084018c22565e3e34293f9351de56c95b31aL131-R131) [[3]](diffhunk://#diff-be46282273957a0b06bf2807906a084018c22565e3e34293f9351de56c95b31aL177-R177) [[4]](diffhunk://#diff-be46282273957a0b06bf2807906a084018c22565e3e34293f9351de56c95b31aL186-R188) [[5]](diffhunk://#diff-be46282273957a0b06bf2807906a084018c22565e3e34293f9351de56c95b31aL210-R210) [[6]](diffhunk://#diff-be46282273957a0b06bf2807906a084018c22565e3e34293f9351de56c95b31aL225-R235) [[7]](diffhunk://#diff-be46282273957a0b06bf2807906a084018c22565e3e34293f9351de56c95b31aL292-R296)

**Scheduler and functional fixes:**

* Fixed a bug in the scheduler by introducing a dedicated store-side (Z) tiling config and iterators, ensuring correct handling of leftover-K tiles and preventing premature retirement of store geometry. This includes new logic for Z tile iteration, FIFO management, and correct assignment of tile dimensions. (`rtl/redmule_scheduler.sv`) [[1]](diffhunk://#diff-640ad143a70a2ea004c9569c1302cfcb9a9777b3234607bfde803ffdaf3be8b1R388-R402) [[2]](diffhunk://#diff-640ad143a70a2ea004c9569c1302cfcb9a9777b3234607bfde803ffdaf3be8b1L405-R417) [[3]](diffhunk://#diff-640ad143a70a2ea004c9569c1302cfcb9a9777b3234607bfde803ffdaf3be8b1R459-R481) [[4]](diffhunk://#diff-640ad143a70a2ea004c9569c1302cfcb9a9777b3234607bfde803ffdaf3be8b1R538-R571) [[5]](diffhunk://#diff-640ad143a70a2ea004c9569c1302cfcb9a9777b3234607bfde803ffdaf3be8b1L582-R678) [[6]](diffhunk://#diff-640ad143a70a2ea004c9569c1302cfcb9a9777b3234607bfde803ffdaf3be8b1L607-R690) [[7]](diffhunk://#diff-640ad143a70a2ea004c9569c1302cfcb9a9777b3234607bfde803ffdaf3be8b1L621-R704)

**Support for misaligned data access:**

* Updated the streamer to support misaligned data widths by introducing `CastDataW` and using it for cast-in and cast-out modules, improving robustness for different data layouts. (`rtl/redmule_streamer.sv`) [[1]](diffhunk://#diff-7ee75cec2f1b924fc3e49b0779cb5fb8d202e9ce96db00b58553eb498c92aad0R51-R53) [[2]](diffhunk://#diff-7ee75cec2f1b924fc3e49b0779cb5fb8d202e9ce96db00b58553eb498c92aad0L239-R242) [[3]](diffhunk://#diff-7ee75cec2f1b924fc3e49b0779cb5fb8d202e9ce96db00b58553eb498c92aad0L389-R392)

**Dependency and test improvements:**

* Updated the `hci` dependency to version 2.6.1 for bugfixes and compatibility. (`Bender.yml`)
* Improved smoke test robustness by separating output capture and the success check. (`scripts/regression-smoke.yml`)

**Build and toolchain fixes:**

* Fixed the Makefile to use the correct prefixed `objcopy` tool, improving cross-compilation compatibility. (`Makefile`)