### PR TITLE
Fix N <= Height

### DIFF
--- a/rtl/redmule_pkg.sv
+++ b/rtl/redmule_pkg.sv
@@ -16,13 +16,7 @@ package redmule_pkg;
   parameter int unsigned MaxDepth             = MaxDim * MaxPipeRegs;
   parameter int unsigned MaxDataW             = MaxDepth * 16;
   parameter int unsigned MisalignedAccessSupportDefault = 0; // default to 0 for compatibility with Snitch
-
-  // Minimum size N handled by the internal control. Any job with n_size <= Height is run "as if"
-  // N = MinimumSizeN for the purpose of the W-load loop / scheduler / z_buffer timing (see
-  // redmule_tiler.sv), while the input operands for the padded N rows [n_size .. MinimumSizeN-1]
-  // are gated to zero so the result is unaffected. This is necessary to enable the controller to
-  // work properly in these corner cases.
-  parameter int unsigned MinimumSizeN         = 16;
+  parameter int unsigned MinimumSizeNFactor   = 2;
 
   parameter int unsigned NumStreamSources     = 3; // X, W, Y
 

--- a/rtl/redmule_pkg.sv
+++ b/rtl/redmule_pkg.sv
@@ -17,13 +17,11 @@ package redmule_pkg;
   parameter int unsigned MaxDataW             = MaxDepth * 16;
   parameter int unsigned MisalignedAccessSupportDefault = 0; // default to 0 for compatibility with Snitch
 
-  // Minimum contraction size (N) handled by the internal control. Any job with n_size <= Height
-  // is run "as if" N = MinimumSizeN for the purpose of the W-load loop / scheduler / z_buffer
-  // timing (see redmule_tiler.sv), while the input operands for the padded contraction rows
-  // [n_size .. MinimumSizeN-1] are gated to zero so the result is unaffected. This restores the
-  // proven-good large-N pacing and fixes the small-N multi-block hang. MinimumSizeN should equal
-  // one full N-tile, i.e. Height*(PipeRegs+1) (= 16 in the default TB geometry); if the array
-  // geometry is re-parameterized away from the default, thread it as a module parameter instead.
+  // Minimum size N handled by the internal control. Any job with n_size <= Height is run "as if"
+  // N = MinimumSizeN for the purpose of the W-load loop / scheduler / z_buffer timing (see
+  // redmule_tiler.sv), while the input operands for the padded N rows [n_size .. MinimumSizeN-1]
+  // are gated to zero so the result is unaffected. This is necessary to enable the controller to
+  // work properly in these corner cases.
   parameter int unsigned MinimumSizeN         = 16;
 
   parameter int unsigned NumStreamSources     = 3; // X, W, Y

--- a/rtl/redmule_pkg.sv
+++ b/rtl/redmule_pkg.sv
@@ -17,6 +17,15 @@ package redmule_pkg;
   parameter int unsigned MaxDataW             = MaxDepth * 16;
   parameter int unsigned MisalignedAccessSupportDefault = 0; // default to 0 for compatibility with Snitch
 
+  // Minimum contraction size (N) handled by the internal control. Any job with n_size <= Height
+  // is run "as if" N = MinimumSizeN for the purpose of the W-load loop / scheduler / z_buffer
+  // timing (see redmule_tiler.sv), while the input operands for the padded contraction rows
+  // [n_size .. MinimumSizeN-1] are gated to zero so the result is unaffected. This restores the
+  // proven-good large-N pacing and fixes the small-N multi-block hang. MinimumSizeN should equal
+  // one full N-tile, i.e. Height*(PipeRegs+1) (= 16 in the default TB geometry); if the array
+  // geometry is re-parameterized away from the default, thread it as a module parameter instead.
+  parameter int unsigned MinimumSizeN         = 16;
+
   parameter int unsigned NumStreamSources     = 3; // X, W, Y
 
   parameter int unsigned XsourceStreamId      = 0;

--- a/rtl/redmule_scheduler.sv
+++ b/rtl/redmule_scheduler.sv
@@ -175,8 +175,19 @@ module redmule_scheduler
 
   assign x_done_en = /*flgs_streamer_i.x_stream_source_flags.ready_start &&*/ x_rows_iter_en && x_rows_iter_q == x_config.x_rows_iter-1 && x_w_iters_q == x_config.w_cols_iter-1 && x_cols_iter_q == x_config.x_cols_iter-1;
 
+  // For N <= Height the contraction is promoted to a full N-tile (MinimumSizeN steps) by the tiler
+  // (see redmule_tiler.sv). The X buffer must then iterate a full D-deep tile so its refill / M-block
+  // row-advance stays in step with the promoted contraction; otherwise it would serve only
+  // x_buffer_slots (= n_size rounded up to Height, = Height for N <= Height) columns and never advance
+  // to the next M-block's X rows (the trailing output tile would reuse the first block's X). This is
+  // the X-side analogue of the W-row promotion and mirrors what already happens for Height < N < D
+  // (e.g. N=12 -> x_buffer_slots = D). The valid-column count `height` stays at the real x_cols_lftovr
+  // so the padded columns [n_size .. D-1] are still zeroed on the way into the buffer.
+  logic small_n_promoted_x;
+  assign small_n_promoted_x = (x_config.n_size <= H);
   assign cntrl_x_buffer_o.height = x_cols_iter_q == x_config.x_cols_iter-1 && x_config.x_cols_lftovr != '0 ? x_config.x_cols_lftovr : D;
-  assign cntrl_x_buffer_o.slots  = x_cols_iter_q == x_config.x_cols_iter-1 && x_config.x_cols_lftovr != '0 ? x_config.x_buffer_slots : D;
+  assign cntrl_x_buffer_o.slots  = small_n_promoted_x ? D
+                                 : (x_cols_iter_q == x_config.x_cols_iter-1 && x_config.x_cols_lftovr != '0 ? x_config.x_buffer_slots : D);
   assign cntrl_x_buffer_o.width  = x_rows_iter_q == x_config.x_rows_iter-1 && x_config.x_rows_lftovr != '0 ? x_config.x_rows_lftovr : W;
 
   /******************************
@@ -360,7 +371,18 @@ module redmule_scheduler
 
   assign w_done_en = w_mat_iters_en && w_mat_iters_q == w_config.x_rows_iter-1;
 
-  assign cntrl_w_buffer_o.height = w_rows_iter_q >= w_config.w_rows_iter-(NumPipeRegs+1) && w_config.w_rows_lftovr != '0 ? w_config.w_rows_lftovr : H;
+  // When N <= Height the tiler promotes the W-row loop to MinimumSizeN (a full N-tile) so the
+  // W-load pacing matches the proven-good large-N case. The extra padded contraction rows
+  // [n_size .. MinimumSizeN-1] must be zeroed at the W-buffer input: rows with a global
+  // contraction index >= real n_size are gated to zero. Since real N <= H, all valid rows fall in
+  // the first Height-deep buffer pass (w_rows_iter_q < H, valid depth = n_size); the second pass
+  // (w_rows_iter_q >= H) is fully invalid (valid depth = 0). This mirrors the operand zeroing the
+  // ordinary partial-N-tile leftover already performs for Height < N < MinimumSizeN.
+  logic small_n_promoted;
+  assign small_n_promoted = (w_config.n_size <= H);
+  assign cntrl_w_buffer_o.height = small_n_promoted
+                                 ? (w_rows_iter_q < H ? w_config.n_size[$clog2(MaxDim)-1:0] : '0)
+                                 : (w_rows_iter_q >= w_config.w_rows_iter-(NumPipeRegs+1) && w_config.w_rows_lftovr != '0 ? w_config.w_rows_lftovr : H);
   assign cntrl_w_buffer_o.width  = w_cols_iter_q == w_config.w_cols_iter-1 && w_config.w_cols_lftovr != '0 ? w_config.w_cols_lftovr : D;
 
   assign cntrl_w_buffer_o.load  = current_state == LOAD_W && ~stall_engine && ~w_done;

--- a/rtl/redmule_scheduler.sv
+++ b/rtl/redmule_scheduler.sv
@@ -175,14 +175,11 @@ module redmule_scheduler
 
   assign x_done_en = /*flgs_streamer_i.x_stream_source_flags.ready_start &&*/ x_rows_iter_en && x_rows_iter_q == x_config.x_rows_iter-1 && x_w_iters_q == x_config.w_cols_iter-1 && x_cols_iter_q == x_config.x_cols_iter-1;
 
-  // For N <= Height the contraction is promoted to a full N-tile (MinimumSizeN steps) by the tiler
+  // For N <= Height, the "internal N" is promoted to a full N-tile (MinimumSizeN steps) by the tiler
   // (see redmule_tiler.sv). The X buffer must then iterate a full D-deep tile so its refill / M-block
   // row-advance stays in step with the promoted contraction; otherwise it would serve only
   // x_buffer_slots (= n_size rounded up to Height, = Height for N <= Height) columns and never advance
-  // to the next M-block's X rows (the trailing output tile would reuse the first block's X). This is
-  // the X-side analogue of the W-row promotion and mirrors what already happens for Height < N < D
-  // (e.g. N=12 -> x_buffer_slots = D). The valid-column count `height` stays at the real x_cols_lftovr
-  // so the padded columns [n_size .. D-1] are still zeroed on the way into the buffer.
+  // to the next M-block's X rows (the trailing output tile would reuse the first block's X).
   logic small_n_promoted_x;
   assign small_n_promoted_x = (x_config.n_size <= H);
   assign cntrl_x_buffer_o.height = x_cols_iter_q == x_config.x_cols_iter-1 && x_config.x_cols_lftovr != '0 ? x_config.x_cols_lftovr : D;
@@ -372,12 +369,11 @@ module redmule_scheduler
   assign w_done_en = w_mat_iters_en && w_mat_iters_q == w_config.x_rows_iter-1;
 
   // When N <= Height the tiler promotes the W-row loop to MinimumSizeN (a full N-tile) so the
-  // W-load pacing matches the proven-good large-N case. The extra padded contraction rows
+  // W-load pacing is not too fast, causing races and hangs. The extra padded N rows
   // [n_size .. MinimumSizeN-1] must be zeroed at the W-buffer input: rows with a global
-  // contraction index >= real n_size are gated to zero. Since real N <= H, all valid rows fall in
+  // N index >= real n_size are gated to zero. Since real N <= H, all valid rows fall in
   // the first Height-deep buffer pass (w_rows_iter_q < H, valid depth = n_size); the second pass
-  // (w_rows_iter_q >= H) is fully invalid (valid depth = 0). This mirrors the operand zeroing the
-  // ordinary partial-N-tile leftover already performs for Height < N < MinimumSizeN.
+  // (w_rows_iter_q >= H) is fully invalid (valid depth = 0).
   logic small_n_promoted;
   assign small_n_promoted = (w_config.n_size <= H);
   assign cntrl_w_buffer_o.height = small_n_promoted

--- a/rtl/redmule_scheduler.sv
+++ b/rtl/redmule_scheduler.sv
@@ -177,7 +177,7 @@ module redmule_scheduler
 
   // For N <= Height, the "internal N" is promoted to a full N-tile (MinimumSizeN steps) by the tiler
   // (see redmule_tiler.sv). The X buffer must then iterate a full D-deep tile so its refill / M-block
-  // row-advance stays in step with the promoted contraction; otherwise it would serve only
+  // row-advance stays in step with the promoted N; otherwise it would serve only
   // x_buffer_slots (= n_size rounded up to Height, = Height for N <= Height) columns and never advance
   // to the next M-block's X rows (the trailing output tile would reuse the first block's X).
   logic small_n_promoted_x;

--- a/rtl/redmule_tiler.sv
+++ b/rtl/redmule_tiler.sv
@@ -61,7 +61,18 @@ assign config_d.w_addr          = config_i.w_addr;
 assign config_d.z_addr          = config_i.z_addr;
 assign config_d.m_size          = config_i.m_size;
 assign config_d.k_size          = config_i.k_size;
-assign config_d.n_size          = config_i.n_size;
+assign config_d.n_size          = config_i.n_size; // real N is carried downstream unchanged (used for operand gating)
+
+// Effective contraction size used ONLY for the W-row loop length / streamer length: any job with
+// N <= Height is promoted to MinimumSizeN so the W-load takes as long as a full N-tile, restoring
+// the large-N scheduler/z_buffer pacing that fixes the small-N multi-block hang. The X-column
+// tiling and the store geometry deliberately keep the real config_d.n_size here (X rows are only
+// n_size wide, so over-reading X would misalign the addresses); the X buffer is instead promoted to
+// a full D-deep tile in redmule_scheduler.sv (cntrl_x_buffer_o.slots) so it advances M-block rows in
+// step with the promoted contraction, and both padded operands are zeroed (X via x_cols_lftovr,
+// W via the cntrl_w_buffer_o.height gating in redmule_scheduler.sv).
+logic [15:0] n_size_eff;
+assign n_size_eff = (config_i.n_size <= Height) ? MinimumSizeN[15:0] : config_i.n_size;
 assign config_d.gemm_ops        = config_i.gemm_ops;
 assign config_d.gemm_input_fmt  = config_i.gemm_input_fmt;
 assign config_d.gemm_output_fmt = config_i.gemm_output_fmt;
@@ -85,14 +96,14 @@ logic [15:0] w_rows_iter_lftovr,
              w_rows_iter_nolftovr;
 assign w_cols_iter_nolftovr = config_d.k_size/(Height*(PipeRegs + 1));
 assign w_rows_iter_lftovr = w_rows_iter_nolftovr + Height - config_d.w_rows_lftovr;
-assign w_rows_iter_nolftovr = config_d.n_size;
+assign w_rows_iter_nolftovr = n_size_eff; // promoted N: W-row loop runs for a full N-tile when N <= Height
 
 // Calculating the residuals along the input dimensions
 assign config_d.x_rows_lftovr = config_d.m_size - (x_rows_iter_nolftovr*Width);
 assign config_d.x_cols_lftovr = config_d.n_size - (x_cols_iter_nolftovr*(Height*(PipeRegs + 1)));
 
 // Calculating the residuals along the weight dimensions
-assign config_d.w_rows_lftovr = config_d.n_size - (Height*(config_d.n_size/Height));
+assign config_d.w_rows_lftovr = n_size_eff - (Height*(n_size_eff/Height)); // promoted N (0 when N <= Height -> full W-row loop)
 assign config_d.w_cols_lftovr = config_d.k_size - (w_cols_iter_nolftovr*(Height*(PipeRegs + 1)));
 
 // Calculate w_cols, x_cols, x_rows iterations

--- a/rtl/redmule_tiler.sv
+++ b/rtl/redmule_tiler.sv
@@ -30,6 +30,14 @@ module redmule_tiler
   output redmule_config_t   config_o
 );
 
+// Minimum size N handled by the internal control. Any job with n_size <= Height is run "as if"
+// N = MinimumSizeN for the purpose of the W-load loop / scheduler / z_buffer timing (see
+// redmule_tiler.sv), while the input operands for the padded N rows [n_size .. MinimumSizeN-1]
+// are gated to zero so the result is unaffected. This is necessary to enable the controller to
+// work properly in these corner cases.
+// The minimum size is defined as MinimumSizeN = MinimumSizeNFactor * Height (e.g., 2*Height)
+localparam MinimumSizeN = MinimumSizeNFactor * Height;
+
 logic clk_en;
 logic clk_int;
 

--- a/rtl/redmule_tiler.sv
+++ b/rtl/redmule_tiler.sv
@@ -63,13 +63,13 @@ assign config_d.m_size          = config_i.m_size;
 assign config_d.k_size          = config_i.k_size;
 assign config_d.n_size          = config_i.n_size; // real N is carried downstream unchanged (used for operand gating)
 
-// Effective contraction size used ONLY for the W-row loop length / streamer length: any job with
+// Effective N size used ONLY for the W-row loop length / streamer length: any job with
 // N <= Height is promoted to MinimumSizeN so the W-load takes as long as a full N-tile, restoring
 // the large-N scheduler/z_buffer pacing that fixes the small-N multi-block hang. The X-column
 // tiling and the store geometry deliberately keep the real config_d.n_size here (X rows are only
 // n_size wide, so over-reading X would misalign the addresses); the X buffer is instead promoted to
 // a full D-deep tile in redmule_scheduler.sv (cntrl_x_buffer_o.slots) so it advances M-block rows in
-// step with the promoted contraction, and both padded operands are zeroed (X via x_cols_lftovr,
+// step with the promoted N, and both padded operands are zeroed (X via x_cols_lftovr,
 // W via the cntrl_w_buffer_o.height gating in redmule_scheduler.sv).
 logic [15:0] n_size_eff;
 assign n_size_eff = (config_i.n_size <= Height) ? MinimumSizeN[15:0] : config_i.n_size;

--- a/rtl/redmule_tiler.sv
+++ b/rtl/redmule_tiler.sv
@@ -36,7 +36,7 @@ module redmule_tiler
 // are gated to zero so the result is unaffected. This is necessary to enable the controller to
 // work properly in these corner cases.
 // The minimum size is defined as MinimumSizeN = MinimumSizeNFactor * Height (e.g., 2*Height)
-localparam MinimumSizeN = MinimumSizeNFactor * Height;
+localparam int unsigned MinimumSizeN = MinimumSizeNFactor * Height;
 
 logic clk_en;
 logic clk_int;

--- a/scripts/regression.yml
+++ b/scripts/regression.yml
@@ -262,3 +262,33 @@ redmule_regression:
   M16_N4_K16: # N < Height (padded rows [4..15] gated to zero)
     path: .
     command: make golden M=16 N=4 K=16 && make sw-clean sw-build M=16 N=4 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=4 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_4_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_4_16
+  M16_N1_K16:
+    path: .
+    command: make golden M=16 N=1 K=16 && make sw-clean sw-build M=16 N=1 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=1 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_1_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_1_16
+  M16_N2_K16:
+    path: .
+    command: make golden M=16 N=2 K=16 && make sw-clean sw-build M=16 N=2 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=2 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_2_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_2_16
+  M16_N3_K16:
+    path: .
+    command: make golden M=16 N=3 K=16 && make sw-clean sw-build M=16 N=3 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=3 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_3_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_3_16
+  M16_N4_K16:
+    path: .
+    command: make golden M=16 N=4 K=16 && make sw-clean sw-build M=16 N=4 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=4 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_4_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_4_16
+  M1_N1_K1:
+    path: .
+    command: make golden M=1 N=1 K=1 && make sw-clean sw-build M=1 N=1 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=1 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_1_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_1_1
+  M1_N2_K1:
+    path: .
+    command: make golden M=1 N=2 K=1 && make sw-clean sw-build M=1 N=2 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=2 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_2_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_2_1
+  M1_N3_K1:
+    path: .
+    command: make golden M=1 N=3 K=1 && make sw-clean sw-build M=1 N=3 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=3 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_3_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_3_1
+  M1_N4_K1:
+    path: .
+    command: make golden M=1 N=4 K=1 && make sw-clean sw-build M=1 N=4 K=1 REDMULE_COMPLEX=0 Gcc= && make hw-run M=1 N=4 K=1 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_1_4_1 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_1_4_1
+  M17_N17_K17:
+    path: .
+    command: make golden M=17 N=17 K=17 && make sw-clean sw-build M=17 N=17 K=17 REDMULE_COMPLEX=0 Gcc= && make hw-run M=17 N=17 K=17 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_17_17_17 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_17_17_17
+  M33_N33_K33:
+    path: .
+    command: make golden M=33 N=33 K=33 && make sw-clean sw-build M=33 N=33 K=33 REDMULE_COMPLEX=0 Gcc= && make hw-run M=33 N=33 K=33 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_33_33_33 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_33_33_33

--- a/scripts/regression.yml
+++ b/scripts/regression.yml
@@ -246,7 +246,7 @@ redmule_regression:
   M8_N32_K8:
     path: .
     command: make golden M=8 N=32 K=8 && make sw-clean sw-build M=8 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_32_8
-  # Small contraction N <= Height promoted to MinimumSizeN (previously HUNG on multi-block).
+  # Small N <= Height promoted to MinimumSizeN (previously HUNG on multi-block).
   M16_N8_K16: # N=Height, 2 M-blocks -> was the canonical hang
     path: .
     command: make golden M=16 N=8 K=16 && make sw-clean sw-build M=16 N=8 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=8 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_8_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_8_16

--- a/scripts/regression.yml
+++ b/scripts/regression.yml
@@ -246,3 +246,19 @@ redmule_regression:
   M8_N32_K8:
     path: .
     command: make golden M=8 N=32 K=8 && make sw-clean sw-build M=8 N=32 K=8 REDMULE_COMPLEX=0 Gcc= && make hw-run M=8 N=32 K=8 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_8_32_8 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_8_32_8
+  # Small contraction N <= Height promoted to MinimumSizeN (previously HUNG on multi-block).
+  M16_N8_K16: # N=Height, 2 M-blocks -> was the canonical hang
+    path: .
+    command: make golden M=16 N=8 K=16 && make sw-clean sw-build M=16 N=8 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=8 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_8_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_8_16
+  M24_N8_K16: # N=Height, 3 M-blocks
+    path: .
+    command: make golden M=24 N=8 K=16 && make sw-clean sw-build M=24 N=8 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=24 N=8 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_24_8_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_24_8_16
+  M32_N8_K16: # N=Height, 4 M-blocks
+    path: .
+    command: make golden M=32 N=8 K=16 && make sw-clean sw-build M=32 N=8 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=32 N=8 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_32_8_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_32_8_16
+  M16_N8_K24: # N=Height, 2 M-blocks + 2 K-tiles (K-leftover)
+    path: .
+    command: make golden M=16 N=8 K=24 && make sw-clean sw-build M=16 N=8 K=24 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=8 K=24 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_8_24 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_8_24
+  M16_N4_K16: # N < Height (padded rows [4..15] gated to zero)
+    path: .
+    command: make golden M=16 N=4 K=16 && make sw-clean sw-build M=16 N=4 K=16 REDMULE_COMPLEX=0 Gcc= && make hw-run M=16 N=4 K=16 REDMULE_COMPLEX=0 target=$Target | tee target/sim/$Target/transcript_16_4_16 && grep -q '\[TB\] - Success!' target/sim/$Target/transcript_16_4_16


### PR DESCRIPTION
This pull request addresses a corner-case bug in the Redmule hardware scheduler and tiler, where jobs with small N (N ≤ Height) could hang when processing multiple M-blocks. The solution is to promote small N jobs to a minimum size (MinimumSizeN = 2 × Height), ensuring correct scheduler pacing and buffer handling. The change is tested with new regression cases.

**Small-N handling and scheduler/tiler logic:**

* Introduced a new parameter `MinimumSizeNFactor` in `redmule_pkg.sv`, and defined `MinimumSizeN` as `MinimumSizeNFactor * Height` in the tiler. This sets the minimum promoted tile size for N. [[1]](diffhunk://#diff-76beb69c9480ceada43e7a215026ce03835d4a5871b3ba59efd97eb5f33361c9R19) [[2]](diffhunk://#diff-3b740004b54dbe1f98d0ad904c69e8e1f65a314e4c18d72ad6c6ced9805b5c7dR33-R40)
* In `redmule_tiler.sv`, jobs with N ≤ Height are now internally promoted to run "as if" N = MinimumSizeN for the W-row loop and scheduler pacing. The real N is still used for operand gating, so results are unaffected. [[1]](diffhunk://#diff-3b740004b54dbe1f98d0ad904c69e8e1f65a314e4c18d72ad6c6ced9805b5c7dL64-R83) [[2]](diffhunk://#diff-3b740004b54dbe1f98d0ad904c69e8e1f65a314e4c18d72ad6c6ced9805b5c7dL88-R114)
* In `redmule_scheduler.sv`, added logic to promote X and W buffer handling for small N cases, ensuring correct buffer slot allocation and zero-gating of padded rows. This fixes the hang on small-N, multi-M-block jobs. [[1]](diffhunk://#diff-640ad143a70a2ea004c9569c1302cfcb9a9777b3234607bfde803ffdaf3be8b1R178-R187) [[2]](diffhunk://#diff-640ad143a70a2ea004c9569c1302cfcb9a9777b3234607bfde803ffdaf3be8b1L363-R381)

**Regression testing:**

* Added multiple regression tests in `regression.yml` to cover small N cases (N = Height, N < Height, and N = 1..4), verifying that the scheduler no longer hangs and all corner cases pass.