### PR TITLE
Enhance Verilator flow and fix REDMULE_FINISHED state issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,17 @@ on: [push, pull_request]
 
 jobs:
   run-hwpe-tests:
-    name: run-hwpe-tests
+    name: run-hwpe-tests (ProbStall=${{ matrix.prob_stall }})
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    strategy:
+      fail-fast: false
+      # The TCDM stall probability is a Verilator elaboration-time parameter
+      # (-GPROB_STALL), so each value needs its own model build: run the whole
+      # regression once without stalls and once with heavy stall injection.
+      matrix:
+        prob_stall: ["0.0", "0.25"]
     env:
       N_PROC: 8
       Target: verilator
@@ -29,7 +36,7 @@ jobs:
     - name: Set up ccache
       uses: hendrikmuhs/ccache-action@v1
       with:
-        key: ${{ runner.os }}-verilator-${{ env.VERILATOR_VERSION }}
+        key: ${{ runner.os }}-verilator-${{ env.VERILATOR_VERSION }}-pstall${{ matrix.prob_stall }}
         max-size: 2G
 
     - name: Install Verilator (prebuilt)
@@ -54,14 +61,16 @@ jobs:
 
     - name: Build verilator model
       run: |
-        make hw-build target=verilator
+        make hw-build target=verilator ProbStall=${{ matrix.prob_stall }} VerilatorJobs=4
 
     - name: Run Tests
       run: |
         scripts/ci-regression.sh
 
+    # Cycle counts are only meaningful for the stall-free model, and two
+    # concurrent auto-pushes would race on the benchmark branch.
     - name: Store benchmark result
-      if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
+      if: matrix.prob_stall == '0.0' && github.event_name == 'push' && github.ref == 'refs/heads/devel'
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: Execution cycles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Run Tests
       run: |
-        scripts/regression-list.sh
+        scripts/ci-regression.sh
 
     - name: Store benchmark result
       if: github.event_name == 'push' && github.ref == 'refs/heads/devel'

--- a/Bender.yml
+++ b/Bender.yml
@@ -66,7 +66,4 @@ sources:
     - target: redmule_test_hwpe
       files:
         - target/sim/src/redmule_tb.sv
-
-    - target: vsim
-      files:
         - target/sim/src/redmule_tb_wrap.sv

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ WORK_PATH = $(SIM_DIR)/work
 # Useful Parameters
 gui      ?= 0
 ipstools ?= 0
-P_STALL  ?= 0.0
 
 ifeq ($(verbose),1)
 	FLAGS += -DVERBOSE

--- a/README.md
+++ b/README.md
@@ -271,7 +271,11 @@ To run the available tests, just do:
 make sw-build
 make hw-run target=verilator (gui=1 to open the GtkWave tool or the Questasim Graphic User Interface depending on the value of `target`)
 ```
-It is possible to run the test introducing a parametric probability of stall by explicitly passing the `P_STALL` parameter while running the test (`P_STALL=0.1` means a stall probability of the 10%).
+It is possible to run the test introducing a parametric probability of TCDM stall by explicitly passing the `ProbStall` parameter (`ProbStall=0.1` means a stall probability of the 10%). With `target=vsim` it is an elaboration parameter, so pass it to `hw-run`; with `target=verilator` it is baked into the model, so pass it to `hw-build` instead:
+```bash
+make hw-run   target=vsim      ProbStall=0.1
+make hw-build target=verilator ProbStall=0.1 && make hw-run target=verilator
+```
 If the `scripts/setup-hwpe.sh` was sourced, the above commands will execute the `sw/redmule.c` example, while if the `scripts/setup-complex.sh` was source, the above commands will execute the `sw/redmule_complex.c` test.
 
 ### Golden Model Generation

--- a/golden-model/FP16/scripts/addmax.py
+++ b/golden-model/FP16/scripts/addmax.py
@@ -55,9 +55,10 @@ f.write('fp16 Y[MID_CH*OUT_CH] = {'+dump.tensor_to_string(Y)+'};\n')
 print("\nComputing add-max..")
 for m in range(m_size):
   for k in range(k_size):
-    Z[m][k] = Y[m][k]
+    val = Y[m][k].float()
     for n in range(n_size):
-      Z[m][k] = torch.max(Z[m][k], torch.add(input = X[m][n], other = W[n][k]))
+      val = torch.max(val, X[m][n].float() + W[n][k].float())
+    Z[m][k] = val.half()
 
 print("\nZ is: ", Z, Z.shape, Z.dtype)
 f.write('fp16 Z[IN_CH*OUT_CH] = {'+dump.tensor_to_string(Z)+'};\n')

--- a/golden-model/FP16/scripts/addmin.py
+++ b/golden-model/FP16/scripts/addmin.py
@@ -55,9 +55,10 @@ f.write('fp16 Y[MID_CH*OUT_CH] = {'+dump.tensor_to_string(Y)+'};\n')
 print("\nComputing add-min..")
 for m in range(m_size):
   for k in range(k_size):
-    Z[m][k] = Y[m][k]
+    val = Y[m][k].float()
     for n in range(n_size):
-      Z[m][k] = torch.min(Z[m][k], torch.add(input = X[m][n], other = W[n][k]))
+      val = torch.min(val, X[m][n].float() + W[n][k].float())
+    Z[m][k] = val.half()
 
 print("\nZ is: ", Z, Z.shape, Z.dtype)
 f.write('fp16 Z[IN_CH*OUT_CH] = {'+dump.tensor_to_string(Z)+'};\n')

--- a/rtl/redmule_ctrl.sv
+++ b/rtl/redmule_ctrl.sv
@@ -146,7 +146,10 @@ module redmule_ctrl
         end
       end
       REDMULE_COMPUTING: begin
-        if (flgs_streamer_i.z_stream_sink_flags.ready_start && fifo_empty_i) begin
+        // busy_o gates clk_acc, so the job must not finish while stores are
+        // still queued in the streamer's store FIFO, or they freeze unsent.
+        if (flgs_streamer_i.z_stream_sink_flags.ready_start && fifo_empty_i
+            && flgs_streamer_i.store_fifo_empty) begin
           next = REDMULE_FINISHED;
         end
       end
@@ -160,7 +163,7 @@ module redmule_ctrl
   /*---------------------------------------------------------------------------------------------*/
   /*                            Other combinational assigmnets                                   */
   /*---------------------------------------------------------------------------------------------*/
-  assign evt_o   = flgs_streamer_i.z_stream_sink_flags.done;
+  assign evt_o   = current == REDMULE_FINISHED;
   assign clear_o = target_clear_i || latch_clear || current == REDMULE_FINISHED;
 
 endmodule : redmule_ctrl

--- a/rtl/redmule_top.sv
+++ b/rtl/redmule_top.sv
@@ -142,11 +142,22 @@ logic            dec_config_valid;
 
 logic config_fifo_empty, config_fifo_full;
 
+// i_control runs on clk_acc and drops busy_o as it enters REDMULE_FINISHED, so the clock must
+// survive one cycle longer than busy_o for it to step back to REDMULE_IDLE. Without this the FSM
+// freezes in REDMULE_FINISHED and evt_o/clear_o stay asserted until the next job is configured.
+logic busy_q;
+always_ff @(posedge clk_i or negedge rst_ni) begin : busy_delay
+  if (~rst_ni)
+    busy_q <= 1'b0;
+  else
+    busy_q <= busy_o;
+end
+
 tc_clk_gating i_acc_clock_gating (
-  .clk_i     ( clk_i                                          ),
-  .en_i      ( dec_config_valid | ~config_fifo_empty | busy_o ),
-  .test_en_i ( '0                                             ),
-  .clk_o     ( clk_acc                                        )
+  .clk_i     ( clk_i                                                   ),
+  .en_i      ( dec_config_valid | ~config_fifo_empty | busy_o | busy_q ),
+  .test_en_i ( '0                                                      ),
+  .clk_o     ( clk_acc                                                 )
 );
 
 /*--------------------------------------------------------------*/
@@ -729,6 +740,14 @@ always_ff @(posedge clk_acc) begin
     $display("[redmule]   receive_x = %b",           redmule_config.receive_x);
   end
 end
+`endif // SYNTHESIS
+
+`ifndef SYNTHESIS
+// clk_acc is gated by busy_o, so it must never fall with stores still
+// queued in the streamer's store FIFO, or they freeze there forever.
+assert property (@(posedge clk_i) disable iff (~rst_ni)
+  $fell(busy_o) |-> flgs_streamer.store_fifo_empty)
+  else $fatal(1, "[redmule] job finished with a non-empty store FIFO: Z stores lost");
 `endif // SYNTHESIS
 
 endmodule : redmule_top

--- a/scripts/ci-regression.sh
+++ b/scripts/ci-regression.sh
@@ -1,0 +1,32 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Andrea Belano <andrea.belano@studio.unibo.it>
+# Yvan Tortorella <yvan.tortorella@unibo.it>
+#
+
+#!/bin/bash
+Red="\e[31m"
+Green="\e[32m"
+EndColor="\e[0m"
+
+if [ -z "$Target" ]; then
+    echo -e "${Red}Error: no Target defined. Set the  Target variable to \"vsim\" or \"verilator\" before continue.${EndColor}"
+    exit 1
+fi
+
+ScriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+BASE_TIMEOUT=500
+REGR_FILE="${REGR_FILE:-$ScriptDir/regression.yml}"
+# Number of tests to run concurrently. Each test now builds into its own
+# per-TEST_ID folder and only reads the shared, already-compiled RTL work
+# library, so the runs are isolated. Override N_PROC per invocation (bounded by
+# available Questa licenses / cores).
+N_PROC="${N_PROC:-4}"
+
+export Target
+
+# be verbose in ci regression
+python3 "$ScriptDir/bwruntests.py" -s --yaml -t $BASE_TIMEOUT -p "$N_PROC" --perf "$ScriptDir/perf.json" "$REGR_FILE"

--- a/target/sim/src/redmule_tb.sv
+++ b/target/sim/src/redmule_tb.sv
@@ -32,7 +32,11 @@ module redmule_tb
   // parameters
   localparam int unsigned NC = 1;
   localparam int unsigned ID = 4; // matches the OpIdWidth used inside redmule_top's target decoder
-  localparam int unsigned DW = 256 + 32; // TCDM data width including MisalignedAccessSupport=1
+  // The datapath/TCDM width is constrained by the array Height by the tiler invariant
+  // DataW == Height*(NumPipeRegs+1)*16 (rtl/redmule_tiler.sv).
+  localparam int unsigned NumPipeRegs  = 1; // drives both the derivation and the wrapper port
+  localparam int unsigned RedmuleDataW = Height*(NumPipeRegs+1)*16; // = D*16
+  localparam int unsigned DW = RedmuleDataW + 32; // TCDM data width including MisalignedAccessSupport=1 (+32b word)
   localparam int unsigned MP = DW/32;
   // HCI size parameter for RedMulE's TCDM port. It must be forwarded to
   // redmule_mm_wrap (redmule_top forwards it verbatim to the streamer, with no
@@ -166,12 +170,12 @@ module redmule_tb
                        other_r_valid    ;
 
   redmule_mm_wrap #(
-    .HCI_SIZE_tcdm           ( HciSizeTcdm ),
-    .DataW                   ( 256         ),
-    .MisalignedAccessSupport ( 1           ),
-    .Height                  ( Height      ),
-    .Width                   ( Width       ),
-    .NumPipeRegs             ( 1           )
+    .HCI_SIZE_tcdm           ( HciSizeTcdm  ),
+    .DataW                   ( RedmuleDataW ),
+    .MisalignedAccessSupport ( 1            ),
+    .Height                  ( Height       ),
+    .Width                   ( Width        ),
+    .NumPipeRegs             ( NumPipeRegs  )
   ) i_redmule_wrap (
     .clk_i       ( clk_i        ),
     .rst_ni      ( rst_ni       ),

--- a/target/sim/src/redmule_tb.sv
+++ b/target/sim/src/redmule_tb.sv
@@ -20,7 +20,9 @@ module redmule_tb
   parameter TCP = 1.0ns, // clock period, 1 GHz clock
   parameter TA  = 0.2ns, // application time
   parameter TT  = 0.8ns,  // test time
-  parameter real  PROB_STALL = 0
+  parameter int unsigned Height = 8,
+  parameter int unsigned Width  = 8,
+  parameter real  PROB_STALL    = 0.0
 )(
   input logic clk_i,
   input logic rst_ni,
@@ -167,8 +169,8 @@ module redmule_tb
     .HCI_SIZE_tcdm           ( HciSizeTcdm ),
     .DataW                   ( 256         ),
     .MisalignedAccessSupport ( 1           ),
-    .Height                  ( 8           ),
-    .Width                   ( 8           ),
+    .Height                  ( Height      ),
+    .Width                   ( Width       ),
     .NumPipeRegs             ( 1           )
   ) i_redmule_wrap (
     .clk_i       ( clk_i        ),
@@ -321,6 +323,9 @@ module redmule_tb
 
     if (!$value$plusargs("STIM_INSTR=%s", stim_instr)) stim_instr = "../../../sw/build/stim_instr.txt";
     if (!$value$plusargs("STIM_DATA=%s", stim_data)) stim_data = "../../../sw/build/stim_data.txt";
+    $display("Height = %d", Height);
+    $display("Width = %d", Width);
+    $display("PROB_STALL = %f", PROB_STALL);
 
     test_mode = 1'b0;
     core_boot_addr = 32'h1C000084;

--- a/target/sim/src/redmule_tb_wrap.sv
+++ b/target/sim/src/redmule_tb_wrap.sv
@@ -7,20 +7,27 @@
 
 timeunit 1ps; timeprecision 1ps;
 
-module redmule_tb_wrap;
-import redmule_pkg::*;
+module redmule_tb_wrap 
+  import redmule_pkg::*;
+#(
+  parameter int unsigned Height = 8,
+  parameter int unsigned Width  = 8,
+  parameter real  PROB_STALL    = 0.0
+);
 
   localparam TCP = 1.0ns; // clock period, 1 GHz clock
   localparam TA  = 0.2ns; // application time
   localparam TT  = 0.8ns; // test time
-  parameter  real  PROB_STALL = 0; // Dummy memories stall probability (passed through the Makefile)
 
   logic clk, rst_n, fetch_enable;
 
   redmule_tb #(
     .TCP ( TCP ),
     .TA  ( TA  ),
-    .TT  ( TT  )
+    .TT  ( TT  ),
+    .Height     ( Height     ),
+    .Width      ( Width      ),
+    .PROB_STALL ( PROB_STALL )
   ) i_redmule_tb (
     .clk_i          ( clk          ),
     .rst_ni         ( rst_n        ),

--- a/target/sim/verilator/verilator.mk
+++ b/target/sim/verilator/verilator.mk
@@ -26,6 +26,9 @@ VerilatorWaves := $(VerilatorDir)/redmule.vcd
 RedmuleHeight ?= 8
 RedmuleWidth ?= 8
 ProbStall ?= 0.05
+# Parallelism for hw-build. With --binary this covers both verilation and the
+# C++ compile of the model.
+VerilatorJobs ?= 4
 
 hw-clean:
 	rm -rf $(VerilatorAbsObjDir) $(VerilatorCompileScript) $(VerilatorWaves) $(VerilatorDir)/transcript
@@ -40,6 +43,7 @@ hw-script:
 hw-build: hw-script
 	OBJCACHE=ccache OPT_SLOW=-O0 OPT_FAST=-O0 OPT_GLOBAL=-O0 $(Verilator) --trace --timing --bbox-unsup \
 	-Wall -Wno-fatal --Wno-lint --Wno-UNOPTFLAT --Wno-MODDUP -Wno-BLKANDNBLK -Wno-ENUMVALUE \
+	-j $(VerilatorJobs) \
 	--x-assign unique --x-initial unique --top-module $(Module)_tb_wrap --Mdir $(VerilatorAbsObjDir) \
 	-GHeight=$(RedmuleHeight) -GWidth=$(RedmuleWidth) -GPROB_STALL=$(ProbStall) \
 	-CFLAGS "-DTbName=$(Vmodule)_tb_wrap -DWafeformPath=$(VerilatorWaves)" --binary \

--- a/target/sim/verilator/verilator.mk
+++ b/target/sim/verilator/verilator.mk
@@ -23,6 +23,9 @@ VerilatorObjDir := $(VerilatorPath)/$(ObjDirName)
 VerilatorAbsObjDir := $(VerilatorDir)/$(ObjDirName)
 VerilatorCompileScript := $(VerilatorDir)/compile.$(target).tcl
 VerilatorWaves := $(VerilatorDir)/redmule.vcd
+RedmuleHeight ?= 8
+RedmuleWidth ?= 8
+ProbStall ?= 0.05
 
 hw-clean:
 	rm -rf $(VerilatorAbsObjDir) $(VerilatorCompileScript) $(VerilatorWaves) $(VerilatorDir)/transcript
@@ -35,18 +38,17 @@ hw-script:
 	> $(VerilatorCompileScript)
 
 hw-build: hw-script
-	$(Verilator) --trace --timing --bbox-unsup \
+	OBJCACHE=ccache OPT_SLOW=-O0 OPT_FAST=-O0 OPT_GLOBAL=-O0 $(Verilator) --trace --timing --bbox-unsup \
 	-Wall -Wno-fatal --Wno-lint --Wno-UNOPTFLAT --Wno-MODDUP -Wno-BLKANDNBLK -Wno-ENUMVALUE \
-	--x-assign unique --x-initial unique --top-module $(Module)_tb --Mdir $(VerilatorAbsObjDir) \
-	-CFLAGS "-DTbName=$(Vmodule)_tb -DWafeformPath=$(VerilatorWaves)" \
-	-sv -cc -f $(VerilatorCompileScript) --exe $(VerilatorSrc)/$(Module)_tb.cpp
-	make -C $(VerilatorAbsObjDir) -f $(Vmodule)_tb.mk $(Vmodule)_tb \
-	OBJCACHE=ccache OPT_SLOW=-O0 OPT_FAST=-O0 OPT_GLOBAL=-O0
+	--x-assign unique --x-initial unique --top-module $(Module)_tb_wrap --Mdir $(VerilatorAbsObjDir) \
+	-GHeight=$(RedmuleHeight) -GWidth=$(RedmuleWidth) -GPROB_STALL=$(ProbStall) \
+	-CFLAGS "-DTbName=$(Vmodule)_tb_wrap -DWafeformPath=$(VerilatorWaves)" --binary \
+	-sv -cc -f $(VerilatorCompileScript)
 
 hw-run:
 	mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR);                    \
-	$(VerilatorAbsObjDir)/$(Vmodule)_tb  \
+	$(VerilatorAbsObjDir)/$(Vmodule)_tb_wrap \
 	+STIM_INSTR=$(STIM_INSTR)           \
 	+STIM_DATA=$(STIM_DATA)             \
 	$(if $(filter 1,$(gui)),,+NOTRACE)

--- a/target/sim/vsim/vsim.mk
+++ b/target/sim/vsim/vsim.mk
@@ -8,6 +8,7 @@
 
 Questa ?=
 Module := redmule
+ProbStall ?= 0.05
 VsimDir := $(SimDir)/$(target)
 VsimCompileScript := $(VsimDir)/compile.$(target).tcl
 VsimWaves := $(VsimDir)/wave.tcl
@@ -42,14 +43,13 @@ hw-script:
 	$(common_targs) $(common_defs) \
 	$(sim_targs)                   \
 	> $(VsimCompileScript)
-	echo 'vopt $(CompileFlags) $(Tb) -o $(Tb)_opt' >> $(VsimCompileScript)
+	echo 'vopt $(CompileFlags) -floatparameters+$(Tb) $(Tb) -o $(Tb)_opt' >> $(VsimCompileScript)
 
 hw-build: hw-script
 	cd $(VsimDir); \
 	$(Questa) $(target) -c    \
 	+STIM_INSTR=$(STIM_INSTR) \
-	+STIM_INSTR=$(STIM_DATA)  \
-	+PROB_STALL=$(P_STALL)    \
+	+STIM_DATA=$(STIM_DATA)   \
 	-do 'quit -code [source $(VsimCompileScript)]'
 
 # Run each test inside its own per-test $(BUILD_DIR) (keyed by TEST_ID) so that
@@ -63,6 +63,7 @@ hw-run:
 	cd $(BUILD_DIR);              \
 	$(QUESTA) $(target) $(Tb)_opt \
 	$(VsimFlags)                  \
+	-gPROB_STALL=$(ProbStall)     \
 	+STIM_INSTR=$(STIM_INSTR)     \
 	+STIM_DATA=$(STIM_DATA)       \
 	-do "run -a"


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the RedMulE simulation and regression infrastructure. We introduced improved testbench configurability, enhanced simulation reliability, and updates to the CI regression flow. The testbenches now support parameterized array sizes and stall probabilities, the hardware modules are more robust against store FIFO issues, and the regression scripts and Makefiles have been updated for better automation and flexibility.
Stall checking is now in place, with testing in place for 25% stalls in the regular regression (tested offline with 10000 tests introduced in `full-regression.yml`).